### PR TITLE
feat: Juno ダーツスコアリングツール

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ public/pdf.js/
 
 # Temporary files
 *.tmp
-*.temp
+*.temp.playwright-cli/

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/jpeg" href="/images/icon.jpg" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/react-pdf": "^6.2.0",
         "file-saver": "^2.0.5",
         "firebase": "^12.0.0",
+        "lucide-react": "^0.577.0",
         "markdown-pdf": "^11.0.0",
         "pdfjs-dist": "^3.11.174",
         "react": "^19.1.0",
@@ -5264,6 +5265,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-pdf": "^6.2.0",
     "file-saver": "^2.0.5",
     "firebase": "^12.0.0",
+    "lucide-react": "^0.577.0",
     "markdown-pdf": "^11.0.0",
     "pdfjs-dist": "^3.11.174",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Home } from './pages/Home'
 import { PDF2MD } from './pages/PDF2MD'
 import CharacterDisplayGenerator from './pages/CharacterDisplayGenerator'
 import DiscordObs from './pages/DiscordObs'
+import Juno from './pages/Juno'
 
 function NotFound() {
   return (
@@ -29,6 +30,7 @@ function App() {
           <Route path="discord-obs" element={<DiscordObs />} />
           <Route path="*" element={<NotFound />} />
         </Route>
+        <Route path="juno" element={<Juno />} />
       </Routes>
     </Router>
   )

--- a/src/components/Juno/CricketScoreBoard.tsx
+++ b/src/components/Juno/CricketScoreBoard.tsx
@@ -1,0 +1,267 @@
+import { ChevronRight } from 'lucide-react'
+
+interface CricketMark {
+  [number: number]: number // 15-20, 25 → マーク数
+}
+
+interface Props {
+  players: { name: string; marks: CricketMark; score: number }[]
+  currentPlayerIndex: number
+  cricketNumbers: number[] // [20, 19, 18, 17, 16, 15, 25]
+  secretMode?: boolean
+  revealedNumbers?: number[]
+}
+
+function CricketMarkIcon({ count }: { count: number }) {
+  if (count === 0) return <span className="text-gray-700">-</span>
+  return (
+    <svg viewBox="0 0 24 24" className="w-6 h-6">
+      {count >= 1 && (
+        <line
+          x1="6"
+          y1="6"
+          x2="18"
+          y2="18"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      )}
+      {count >= 2 && (
+        <line
+          x1="18"
+          y1="6"
+          x2="6"
+          y2="18"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      )}
+      {count >= 3 && (
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+        />
+      )}
+    </svg>
+  )
+}
+
+function getNumberLabel(n: number): string {
+  return n === 25 ? 'BULL' : String(n)
+}
+
+export default function CricketScoreBoard({
+  players,
+  currentPlayerIndex,
+  cricketNumbers,
+  secretMode,
+  revealedNumbers,
+}: Props) {
+  const playerColors = ['#ff6b6b', '#00d4ff', '#ffaa00', '#00ff88']
+
+  // ナンバーが全プレイヤーともクローズ済みか判定
+  const isClosed = (num: number) =>
+    players.every((p) => (p.marks[num] ?? 0) >= 3)
+
+  // プレイヤーを左右に分ける（常に4スロット対応: 左2 + 右2）
+  const leftPlayers: (number | null)[] = [null, null]
+  const rightPlayers: (number | null)[] = [null, null]
+
+  if (players.length === 1) {
+    leftPlayers[0] = 0
+  } else if (players.length === 2) {
+    leftPlayers[0] = 0
+    rightPlayers[0] = 1
+  } else if (players.length === 3) {
+    leftPlayers[0] = 0
+    leftPlayers[1] = 1
+    rightPlayers[0] = 2
+  } else if (players.length >= 4) {
+    leftPlayers[0] = 0
+    leftPlayers[1] = 1
+    rightPlayers[0] = 2
+    rightPlayers[1] = 3
+  }
+
+  // 左右に実際いるプレイヤー数をカウント
+  const leftCount = leftPlayers.filter((p) => p !== null).length
+  const rightCount = rightPlayers.filter((p) => p !== null).length
+  const useSpan = players.length <= 2
+
+  // 5列グリッド: 左2 | ナンバー3rem | 右2
+  const gridTemplate = 'repeat(2, 1fr) 3rem repeat(2, 1fr)'
+
+  // プレイヤースコア表示を描画
+  const renderPlayerScore = (playerIndex: number) => {
+    const player = players[playerIndex]
+    return (
+      <div
+        style={{
+          backgroundColor: currentPlayerIndex === playerIndex ? `${playerColors[playerIndex]}15` : 'transparent',
+          border: currentPlayerIndex === playerIndex ? `1.5px solid ${playerColors[playerIndex]}50` : '1.5px solid transparent',
+          borderRadius: '6px',
+          padding: '6px 4px',
+        }}
+      >
+        <div
+          className="text-xs font-medium mb-1"
+          style={{
+            color:
+              currentPlayerIndex === playerIndex ? playerColors[playerIndex] : '#9ca3af',
+          }}
+        >
+          {currentPlayerIndex === playerIndex && <ChevronRight size={12} className="inline mr-0.5" />}
+          {player.name}
+        </div>
+        <div
+          className="text-3xl font-bold tabular-nums"
+          style={{ color: playerColors[playerIndex] }}
+        >
+          {player.score}
+        </div>
+      </div>
+    )
+  }
+
+  // マークを描画
+  const renderMark = (playerIndex: number, num: number) => {
+    const player = players[playerIndex]
+    const isRevealed = !secretMode || revealedNumbers?.includes(num)
+    return (
+      <span style={{ color: playerColors[playerIndex] }}>
+        {isRevealed ? (
+          <CricketMarkIcon count={player.marks[num] ?? 0} />
+        ) : (
+          <span className="text-gray-700">-</span>
+        )}
+      </span>
+    )
+  }
+
+  return (
+    <div
+      className="rounded-lg overflow-hidden text-white select-none"
+      style={{ backgroundColor: '#1a1a2e' }}
+    >
+      {/* スコア表示 */}
+      <div
+        className="text-center py-3 px-2"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: gridTemplate,
+          gap: '0.5rem',
+        }}
+      >
+        {/* 左側プレイヤー */}
+        {leftPlayers.filter((p) => p !== null).map((pIdx) => (
+          <div
+            key={`l${pIdx}`}
+            style={{
+              gridColumn: useSpan && leftCount === 1 ? 'span 2' : undefined,
+            }}
+          >
+            {renderPlayerScore(pIdx!)}
+          </div>
+        ))}
+        {/* 左側が0人の場合、空のspan 2セル */}
+        {leftCount === 0 && <div style={{ gridColumn: 'span 2' }} />}
+
+        {/* 中央（ナンバー列スペース） */}
+        <div />
+
+        {/* 右側プレイヤー */}
+        {rightPlayers.filter((p) => p !== null).map((pIdx) => (
+          <div
+            key={`r${pIdx}`}
+            style={{
+              gridColumn: useSpan && rightCount === 1 ? 'span 2' : undefined,
+            }}
+          >
+            {renderPlayerScore(pIdx!)}
+          </div>
+        ))}
+        {/* 右側が0人の場合、空のspan 2セル */}
+        {rightCount === 0 && <div style={{ gridColumn: 'span 2' }} />}
+      </div>
+
+      {/* マーク表 */}
+      <div className="px-2 pb-2">
+        {cricketNumbers.map((num) => {
+          const isRevealed = !secretMode || revealedNumbers?.includes(num)
+          const closed = isClosed(num)
+          return (
+            <div
+              key={num}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: gridTemplate,
+                gap: '0.5rem',
+                alignItems: 'center',
+                paddingTop: '0.375rem',
+                paddingBottom: '0.375rem',
+                borderTop: '1px solid rgba(255, 255, 255, 0.1)',
+                opacity: closed ? 0.35 : 1,
+              }}
+            >
+              {/* 左側プレイヤーのマーク */}
+              {leftPlayers.filter((p) => p !== null).map((pIdx) => (
+                <div
+                  key={`l${pIdx}`}
+                  className="flex justify-center"
+                  style={{
+                    backgroundColor:
+                      currentPlayerIndex === pIdx
+                        ? `${playerColors[pIdx]}10`
+                        : 'transparent',
+                    gridColumn: useSpan && leftCount === 1 ? 'span 2' : undefined,
+                  }}
+                >
+                  {renderMark(pIdx!, num)}
+                </div>
+              ))}
+              {/* 左側が0人の場合、空のspan 2セル */}
+              {leftCount === 0 && <div style={{ gridColumn: 'span 2' }} />}
+
+              {/* 中央（ナンバーラベル） */}
+              <div
+                className="text-center text-sm font-bold"
+                style={{
+                  backgroundColor: '#252547',
+                  borderRadius: 4,
+                  padding: '2px 0',
+                }}
+              >
+                {isRevealed ? getNumberLabel(num) : '???'}
+              </div>
+
+              {/* 右側プレイヤーのマーク */}
+              {rightPlayers.filter((p) => p !== null).map((pIdx) => (
+                <div
+                  key={`r${pIdx}`}
+                  className="flex justify-center"
+                  style={{
+                    backgroundColor:
+                      currentPlayerIndex === pIdx
+                        ? `${playerColors[pIdx]}10`
+                        : 'transparent',
+                    gridColumn: useSpan && rightCount === 1 ? 'span 2' : undefined,
+                  }}
+                >
+                  {renderMark(pIdx!, num)}
+                </div>
+              ))}
+              {/* 右側が0人の場合、空のspan 2セル */}
+              {rightCount === 0 && <div style={{ gridColumn: 'span 2' }} />}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Juno/DartBoard.tsx
+++ b/src/components/Juno/DartBoard.tsx
@@ -1,0 +1,196 @@
+import type { Segment, DartThrow } from '../../types/juno.types'
+import { generateBoardPaths, getSegmentColor, getNumberLabelPositions, BOARD_SIZE, BOARD_CENTER, RADIUS } from '../../data/dartboard'
+import { DartBoardSegment } from './DartBoardSegment'
+import { useMemo } from 'react'
+
+interface Props {
+  onHit: (segment: Segment) => void
+  onMiss: () => void
+  disabled?: boolean
+  currentThrows?: DartThrow[]
+  waitingConfirm?: boolean
+  onConfirm?: () => void
+  cricketNumbers?: number[]
+  closedNumbers?: number[]
+  playerColor?: string
+  deadNumbers?: number[]
+  checkoutSegments?: Segment[]
+  triedMissNumbers?: number[]
+  hideThrowHighlight?: boolean
+}
+
+function segmentKey(s: Segment): string {
+  return `${s.number}-${s.multiplier}`
+}
+
+export function DartBoard({ onHit, onMiss, disabled, currentThrows = [], waitingConfirm, onConfirm, cricketNumbers, closedNumbers, playerColor, deadNumbers, checkoutSegments = [], triedMissNumbers, hideThrowHighlight = false }: Props) {
+  const paths = useMemo(() => generateBoardPaths(), [])
+  const labels = useMemo(() => getNumberLabelPositions(), [])
+
+  const hitThrowIndex = useMemo(() => {
+    const map = new Map<string, number>()
+    for (let i = 0; i < currentThrows.length; i++) {
+      const t = currentThrows[i]
+      if (t === 'miss') continue
+      map.set(segmentKey(t), i)
+    }
+    return map
+  }, [currentThrows])
+
+  const closedSet = useMemo(() => new Set(closedNumbers ?? []), [closedNumbers])
+  const cricketSet = useMemo(() => new Set(cricketNumbers ?? []), [cricketNumbers])
+  const deadSet = useMemo(() => new Set(deadNumbers ?? []), [deadNumbers])
+  const triedMissSet = useMemo(() => new Set(triedMissNumbers ?? []), [triedMissNumbers])
+  const checkoutKeys = useMemo(() => new Set(checkoutSegments.map(segmentKey)), [checkoutSegments])
+
+  const { segmentPaths, missPath } = useMemo(() => {
+    const segments = []
+    let miss = null
+    for (const p of paths) {
+      if (p.segment === 'miss') {
+        miss = p
+      } else {
+        segments.push(p)
+      }
+    }
+    return { segmentPaths: segments, missPath: miss }
+  }, [paths])
+
+  return (
+    <div className={`flex items-center justify-center h-full ${disabled ? 'pointer-events-none' : ''}`}>
+      <svg
+        viewBox={`-20 -20 ${BOARD_SIZE + 40} ${BOARD_SIZE + 40}`}
+        className="w-full h-full max-w-md"
+      >
+        {/* ボード背景 */}
+        <circle cx={BOARD_CENTER} cy={BOARD_CENTER} r={RADIUS.outerDouble + 5} fill="#2A2A2A" />
+
+        {/* セグメント */}
+        {segmentPaths.map((p, i) => {
+          const segment = p.segment as Segment
+          const isDead = deadNumbers && deadSet.has(segment.number)
+          const isDimmed = isDead || (cricketNumbers && !cricketSet.has(segment.number))
+          const isClosed = !isDead && closedNumbers && closedSet.has(segment.number)
+          const isTriedMiss = triedMissNumbers && triedMissSet.has(segment.number)
+          return (
+            <g key={i}>
+              <DartBoardSegment
+                d={p.d}
+                fill={getSegmentColor(p.boardIndex, segment.multiplier, segment.number)}
+                segment={segment}
+                onHit={onHit}
+                hitThrowIndex={hideThrowHighlight ? -1 : (hitThrowIndex.get(segmentKey(segment)) ?? -1)}
+                dimmed={isDimmed}
+                isCheckout={checkoutKeys.has(segmentKey(segment))}
+              />
+              {/* クローズしたセグメントのハイライト層 */}
+              {isClosed && playerColor && (() => {
+                const isDoubleTriple = segment.multiplier === 'double' || segment.multiplier === 'triple'
+                return (
+                  <path
+                    d={p.d}
+                    fill={playerColor}
+                    opacity={isDoubleTriple ? 0.7 : 0.45}
+                    style={{
+                      pointerEvents: 'none',
+                      filter: isDoubleTriple
+                        ? `drop-shadow(0 0 6px ${playerColor}) drop-shadow(0 0 12px ${playerColor})`
+                        : `drop-shadow(0 0 4px ${playerColor})`,
+                    }}
+                  />
+                )
+              })()}
+
+              {/* 紫オーバーレイ（ハズレ or シークレット時の全員クローズ） */}
+              {(isTriedMiss || (isDead && triedMissNumbers)) && (
+                <path
+                  d={p.d}
+                  fill="#6b21a8"
+                  opacity={0.5}
+                  style={{
+                    pointerEvents: 'none',
+                    filter: 'drop-shadow(0 0 4px #6b21a8)',
+                  }}
+                />
+              )}
+            </g>
+          )
+        })}
+
+        {/* MISSリング */}
+        {missPath && (
+          <>
+            <path
+              d={missPath.d}
+              fill="#1a1a1a"
+              stroke="#555"
+              strokeWidth={0.5}
+              style={{ cursor: 'pointer' }}
+              onClick={onMiss}
+            />
+            <text
+              x={BOARD_CENTER}
+              y={BOARD_CENTER - (RADIUS.outerDouble + RADIUS.missRing) / 2}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill="#888"
+              fontSize={12}
+              fontWeight="bold"
+              style={{ pointerEvents: 'none', userSelect: 'none' }}
+            >
+              MISS
+            </text>
+          </>
+        )}
+
+        {/* 数字ラベル */}
+        {labels.map((l) => (
+          <text
+            key={l.number}
+            x={l.x}
+            y={l.y}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="white"
+            fontSize={14}
+            fontWeight="bold"
+            style={{ pointerEvents: 'none', userSelect: 'none' }}
+          >
+            {l.number}
+          </text>
+        ))}
+
+        {/* 確認フェーズ: 円形オーバーレイ */}
+        {waitingConfirm && (
+          <>
+            <circle
+              cx={BOARD_CENTER}
+              cy={BOARD_CENTER}
+              r={RADIUS.missRing}
+              fill="rgba(0,0,0,0.4)"
+              style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+              onClick={onConfirm}
+            />
+            <text
+              x={BOARD_CENTER}
+              y={BOARD_CENTER}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill="white"
+              fontSize={20}
+              fontWeight="900"
+              letterSpacing={4}
+              style={{
+                pointerEvents: 'none',
+                userSelect: 'none',
+                filter: 'drop-shadow(0 0 15px rgba(255,255,255,0.8)) drop-shadow(0 0 30px rgba(255,255,255,0.5))',
+              }}
+            >
+              NEXT PLAYER →
+            </text>
+          </>
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/src/components/Juno/DartBoardSegment.tsx
+++ b/src/components/Juno/DartBoardSegment.tsx
@@ -1,0 +1,43 @@
+import type { Segment } from '../../types/juno.types'
+
+interface Props {
+  d: string
+  fill: string
+  segment: Segment
+  onHit: (segment: Segment) => void
+  hitThrowIndex?: number  // -1=未ヒット, 0=1投目, 1=2投目, 2=3投目
+  dimmed?: boolean
+  isCheckout?: boolean
+}
+
+const THROW_COLORS = ['#00d4ff', '#00ff88', '#ffaa00'] as const
+const CHECKOUT_COLOR = '#ffd700'
+
+export function DartBoardSegment({ d, fill, segment, onHit, hitThrowIndex = -1, dimmed = false, isCheckout = false }: Props) {
+  const isHit = hitThrowIndex >= 0
+  const hitColor = isHit ? THROW_COLORS[hitThrowIndex] : null
+
+  const activeFill = isHit ? hitColor! : isCheckout ? CHECKOUT_COLOR : fill
+  const activeFilter = isHit
+    ? `drop-shadow(0 0 8px ${hitColor})`
+    : isCheckout
+    ? `drop-shadow(0 0 6px ${CHECKOUT_COLOR}) drop-shadow(0 0 12px ${CHECKOUT_COLOR})`
+    : 'none'
+  const activeOpacity = dimmed && !isHit && !isCheckout ? 0.15 : 1
+
+  return (
+    <path
+      d={d}
+      fill={activeFill}
+      stroke="#555"
+      strokeWidth={0.5}
+      opacity={activeOpacity}
+      style={{
+        cursor: 'pointer',
+        transition: 'fill 0.15s, filter 0.15s, opacity 0.15s',
+        filter: activeFilter,
+      }}
+      onClick={() => onHit(segment)}
+    />
+  )
+}

--- a/src/components/Juno/GameView.tsx
+++ b/src/components/Juno/GameView.tsx
@@ -1,0 +1,301 @@
+import type { GameState, GameAction, Segment, DartThrow, GameModeStrategy, DartNumber } from '../../types/juno.types'
+import { getThrowScore, formatThrow, isCricketMode } from '../../types/juno.types'
+import { useMemo } from 'react'
+import { DartBoard } from './DartBoard'
+import { ScoreBoard } from './ScoreBoard'
+import { ThrowHistory } from './ThrowHistory'
+import CricketScoreBoard from './CricketScoreBoard'
+import { CRICKET_NUMBERS } from '../../data/gameModes'
+
+interface Props {
+  state: GameState
+  strategy: GameModeStrategy
+  dispatch: React.Dispatch<GameAction>
+}
+
+// チェックアウト計算用の型
+interface CheckoutOption {
+  darts: DartThrow[]
+  score: number
+}
+
+// 使用可能な得点を生成
+function getAvailableScores(): Array<{ score: number; label: string }> {
+  const scores: Array<{ score: number; label: string }> = []
+
+  // シングル 1-20
+  for (let n = 1; n <= 20; n++) {
+    scores.push({ score: n, label: `S${n}` })
+  }
+
+  // ダブル 2-40, 50 (ブル)
+  for (let n = 1; n <= 20; n++) {
+    scores.push({ score: n * 2, label: `D${n}` })
+  }
+  scores.push({ score: 50, label: 'BULL' })
+
+  // トリプル 3-60
+  for (let n = 1; n <= 20; n++) {
+    scores.push({ score: n * 3, label: `T${n}` })
+  }
+
+  // 外ブル 25
+  scores.push({ score: 25, label: 'OUT BULL' })
+
+  return scores
+}
+
+// チェックアウト計算（再帰的に全パターンを探索）
+function findCheckout(remaining: number, dartsLeft: number): DartThrow[] | null {
+  const availableScores = getAvailableScores()
+
+  function backtrack(target: number, darts: number, current: DartThrow[]): DartThrow[] | null {
+    if (darts === 0) {
+      return target === 0 ? current : null
+    }
+    if (target <= 0) {
+      return null
+    }
+
+    for (const { score } of availableScores) {
+      if (score > target) continue
+
+      let dart: DartThrow
+      if (score === 50) {
+        // BULL (ダブル25)
+        dart = { number: 25, multiplier: 'double' }
+      } else if (score === 25) {
+        // OUT BULL (シングル25)
+        dart = { number: 25, multiplier: 'single' }
+      } else if (score % 3 === 0 && score >= 3 && score <= 60) {
+        // トリプル
+        const num = (score / 3) as DartNumber
+        dart = { number: num, multiplier: 'triple' }
+      } else if (score % 2 === 0 && score >= 2 && score <= 40) {
+        // ダブル
+        const num = (score / 2) as DartNumber
+        dart = { number: num, multiplier: 'double' }
+      } else if (score >= 1 && score <= 20) {
+        // シングル
+        dart = { number: score as DartNumber, multiplier: 'single' }
+      } else {
+        continue
+      }
+
+      const result = backtrack(target - score, darts - 1, [...current, dart])
+      if (result) return result
+    }
+
+    return null
+  }
+
+  // 残り投球数から少ない順に探索
+  for (let d = 1; d <= dartsLeft; d++) {
+    const result = backtrack(remaining, d, [])
+    if (result) return result
+  }
+
+  return null
+}
+
+export function GameView({ state, strategy, dispatch }: Props) {
+  const currentPlayer = state.players[state.currentPlayerIndex]
+  const isRoundComplete = state.currentThrows.length >= 3
+
+  const handleHit = (segment: Segment) => {
+    if (isRoundComplete) return
+    dispatch({ type: 'RECORD_THROW', dart: segment })
+  }
+
+  const handleMiss = () => {
+    if (isRoundComplete) return
+    dispatch({ type: 'RECORD_THROW', dart: 'miss' })
+  }
+
+  const handleSelect = (dart: DartThrow) => {
+    if (isRoundComplete) return
+    dispatch({ type: 'RECORD_THROW', dart })
+  }
+
+  const handleConfirm = () => {
+    dispatch({ type: 'CONFIRM_TURN' })
+  }
+
+  const canUndo = state.currentThrows.length > 0 || state.currentRound > 0 || state.currentPlayerIndex > 0
+
+  const totalScore = state.mode === 'zero-one'
+    ? (state.startScore ?? 501) - strategy.getTotalScore(currentPlayer)
+    : isCricketMode(state.mode)
+    ? (state.cricketScores?.[state.currentPlayerIndex] ?? 0)
+    : strategy.getTotalScore(currentPlayer)
+
+  // チェックアウト計算（01モードのみ）
+  const checkoutDarts = useMemo(() => {
+    if (state.mode !== 'zero-one' || state.currentThrows.length >= 3) return null
+    const currentRoundScore = state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
+    const remaining = totalScore - currentRoundScore
+    const dartsLeft = 3 - state.currentThrows.length
+    if (remaining > 0 && remaining <= 180 && dartsLeft > 0) {
+      return findCheckout(remaining, dartsLeft)
+    }
+    return null
+  }, [state.mode, state.currentThrows, totalScore])
+
+  const checkoutText = checkoutDarts
+    ? checkoutDarts.map(d => formatThrow(d)).join(' → ')
+    : null
+
+  // 1投でクリアできる全セグメント（盤面ハイライト用）
+  const checkoutSegments = useMemo(() => {
+    if (state.mode !== 'zero-one' || state.currentThrows.length >= 3) return []
+    const currentRoundScore = state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
+    const remaining = totalScore - currentRoundScore
+    if (remaining <= 0) return []
+    const segments: Segment[] = []
+    // シングル 1-20
+    for (let n = 1; n <= 20; n++) {
+      if (n === remaining) segments.push({ number: n as DartNumber, multiplier: 'single' })
+      if (n * 2 === remaining) segments.push({ number: n as DartNumber, multiplier: 'double' })
+      if (n * 3 === remaining) segments.push({ number: n as DartNumber, multiplier: 'triple' })
+    }
+    // ブル
+    if (remaining === 25) segments.push({ number: 25, multiplier: 'single' })
+    if (remaining === 50) segments.push({ number: 25, multiplier: 'double' })
+    return segments
+  }, [state.mode, state.currentThrows, totalScore])
+
+  // シークレットCricket: 投げたけどsecretNumbersに含まれないハズレナンバー
+  const triedMissNumbers = state.mode === 'cricket-secret' && state.secretNumbers
+    ? (() => {
+        const tried = new Set<number>()
+        for (const player of state.players) {
+          for (const round of player.rounds) {
+            for (const t of round) {
+              if (t !== 'miss') tried.add(t.number)
+            }
+          }
+        }
+        for (const t of state.currentThrows) {
+          if (t !== 'miss') tried.add(t.number)
+        }
+        // secretNumbersに含まれないもの = ハズレ
+        return [...tried].filter(n => !state.secretNumbers!.includes(n))
+      })()
+    : undefined
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* 上半分: スコア情報 */}
+      <div className="flex-1 flex flex-col gap-1 overflow-hidden">
+        {/* ヘッダー行（左: スコア情報, 右: ラウンド+戻るボタン） */}
+        <div className="flex items-center px-2 py-1 flex-shrink-0 gap-2">
+          {/* プレイヤー名とスコア */}
+          <p className="text-xs text-[#00d4ff] font-semibold whitespace-nowrap shrink-0">
+            {currentPlayer.name}
+          </p>
+          <p
+            className="text-3xl font-mono font-black text-white leading-none shrink-0"
+            style={{ textShadow: '0 0 20px #00d4ff, 0 0 40px #00d4ff' }}
+          >
+            {totalScore}
+          </p>
+          {/* スペーサー */}
+          <div className="flex-1" />
+          {/* ラウンド情報 */}
+          <p className="text-xs text-gray-300 font-semibold whitespace-nowrap shrink-0">
+            R{state.currentRound + 1}/{state.maxRounds} · {state.currentThrows.length}/3投
+          </p>
+          {/* 戻るボタン */}
+          <button
+            onClick={() => dispatch({ type: 'RESET_GAME' })}
+            className="text-lg text-gray-400 hover:text-white transition-colors shrink-0"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* スコアボード */}
+        <div className="flex-shrink-0 overflow-y-auto">
+          {isCricketMode(state.mode) && state.cricketMarks && state.cricketScores ? (
+            <CricketScoreBoard
+              players={state.players.map((p, i) => ({
+                name: p.name,
+                marks: state.cricketMarks![i] ?? {},
+                score: state.cricketScores![i] ?? 0,
+              }))}
+              currentPlayerIndex={state.currentPlayerIndex}
+              cricketNumbers={state.mode === 'cricket-secret' ? (state.secretNumbers ?? []) : CRICKET_NUMBERS}
+              secretMode={state.mode === 'cricket-secret'}
+              revealedNumbers={state.revealedNumbers}
+            />
+          ) : (
+            <ScoreBoard state={state} strategy={strategy} />
+          )}
+        </div>
+
+        {/* 投球履歴 */}
+        <div className="flex-shrink-0">
+          <ThrowHistory
+            throws={state.currentThrows}
+            onUndo={() => dispatch({ type: 'UNDO_THROW' })}
+            canUndo={canUndo}
+            isCricket={isCricketMode(state.mode)}
+            secretNumbers={state.mode === 'cricket-secret' ? state.secretNumbers : undefined}
+          />
+        </div>
+
+        {/* チェックアウト表示（01モード専用） */}
+        {checkoutText && (
+          <div className="flex-shrink-0 bg-red-900/60 rounded-md px-3 py-1 text-center mx-2 mb-2">
+            <p className="text-sm font-mono text-white tracking-wider">
+              CHECKOUT: {checkoutText}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* 下半分: ダーツボード */}
+      <div className="flex-1 min-h-0">
+        <DartBoard
+          onHit={handleHit}
+          onMiss={handleMiss}
+          disabled={isRoundComplete || state.waitingConfirm}
+          currentThrows={state.currentThrows}
+          waitingConfirm={state.waitingConfirm}
+          onConfirm={handleConfirm}
+          cricketNumbers={
+            isCricketMode(state.mode)
+              ? (state.mode === 'cricket-secret' ? state.revealedNumbers : CRICKET_NUMBERS)
+              : undefined
+          }
+          closedNumbers={
+            isCricketMode(state.mode) && state.cricketMarks
+              ? Object.entries(state.cricketMarks[state.currentPlayerIndex] ?? {})
+                  .filter(([num, marks]) => {
+                    const numInt = parseInt(num)
+                    return marks >= 3 && (!state.revealedNumbers || state.revealedNumbers.includes(numInt))
+                  })
+                  .map(([num]) => parseInt(num))
+              : undefined
+          }
+          playerColor={
+            isCricketMode(state.mode)
+              ? ['#ff6b6b', '#00d4ff', '#ffaa00', '#00ff88'][state.currentPlayerIndex]
+              : undefined
+          }
+          checkoutSegments={checkoutSegments}
+          deadNumbers={
+            isCricketMode(state.mode) && state.cricketMarks
+              ? (state.mode === 'cricket-secret' ? state.secretNumbers : CRICKET_NUMBERS)
+                  ?.filter(n =>
+                    state.players.every((_, pi) => (state.cricketMarks![pi]?.[n] ?? 0) >= 3)
+                  )
+              : undefined
+          }
+          triedMissNumbers={triedMissNumbers}
+          hideThrowHighlight={state.mode === 'cricket-secret'}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/Juno/GameView.tsx
+++ b/src/components/Juno/GameView.tsx
@@ -123,11 +123,9 @@ export function GameView({ state, strategy, dispatch }: Props) {
   // チェックアウト計算（01モードのみ）
   const checkoutDarts = useMemo(() => {
     if (state.mode !== 'zero-one' || state.currentThrows.length >= 3) return null
-    const currentRoundScore = state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
-    const remaining = totalScore - currentRoundScore
     const dartsLeft = 3 - state.currentThrows.length
-    if (remaining > 0 && remaining <= 180 && dartsLeft > 0) {
-      return findCheckout(remaining, dartsLeft)
+    if (totalScore > 0 && totalScore <= 180 && dartsLeft > 0) {
+      return findCheckout(totalScore, dartsLeft)
     }
     return null
   }, [state.mode, state.currentThrows, totalScore])
@@ -139,19 +137,15 @@ export function GameView({ state, strategy, dispatch }: Props) {
   // 1投でクリアできる全セグメント（盤面ハイライト用）
   const checkoutSegments = useMemo(() => {
     if (state.mode !== 'zero-one' || state.currentThrows.length >= 3) return []
-    const currentRoundScore = state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
-    const remaining = totalScore - currentRoundScore
-    if (remaining <= 0) return []
+    if (totalScore <= 0) return []
     const segments: Segment[] = []
-    // シングル 1-20
     for (let n = 1; n <= 20; n++) {
-      if (n === remaining) segments.push({ number: n as DartNumber, multiplier: 'single' })
-      if (n * 2 === remaining) segments.push({ number: n as DartNumber, multiplier: 'double' })
-      if (n * 3 === remaining) segments.push({ number: n as DartNumber, multiplier: 'triple' })
+      if (n === totalScore) segments.push({ number: n as DartNumber, multiplier: 'single' })
+      if (n * 2 === totalScore) segments.push({ number: n as DartNumber, multiplier: 'double' })
+      if (n * 3 === totalScore) segments.push({ number: n as DartNumber, multiplier: 'triple' })
     }
-    // ブル
-    if (remaining === 25) segments.push({ number: 25, multiplier: 'single' })
-    if (remaining === 50) segments.push({ number: 25, multiplier: 'double' })
+    if (totalScore === 25) segments.push({ number: 25, multiplier: 'single' })
+    if (totalScore === 50) segments.push({ number: 25, multiplier: 'double' })
     return segments
   }, [state.mode, state.currentThrows, totalScore])
 

--- a/src/components/Juno/GameView.tsx
+++ b/src/components/Juno/GameView.tsx
@@ -13,12 +13,6 @@ interface Props {
   dispatch: React.Dispatch<GameAction>
 }
 
-// チェックアウト計算用の型
-interface CheckoutOption {
-  darts: DartThrow[]
-  score: number
-}
-
 // 使用可能な得点を生成
 function getAvailableScores(): Array<{ score: number; label: string }> {
   const scores: Array<{ score: number; label: string }> = []
@@ -112,22 +106,19 @@ export function GameView({ state, strategy, dispatch }: Props) {
     dispatch({ type: 'RECORD_THROW', dart: 'miss' })
   }
 
-  const handleSelect = (dart: DartThrow) => {
-    if (isRoundComplete) return
-    dispatch({ type: 'RECORD_THROW', dart })
-  }
-
   const handleConfirm = () => {
     dispatch({ type: 'CONFIRM_TURN' })
   }
 
   const canUndo = state.currentThrows.length > 0 || state.currentRound > 0 || state.currentPlayerIndex > 0
 
+  const currentRoundScore = state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
+
   const totalScore = state.mode === 'zero-one'
-    ? (state.startScore ?? 501) - strategy.getTotalScore(currentPlayer)
+    ? (state.startScore ?? 501) - strategy.getTotalScore(currentPlayer) - currentRoundScore
     : isCricketMode(state.mode)
     ? (state.cricketScores?.[state.currentPlayerIndex] ?? 0)
-    : strategy.getTotalScore(currentPlayer)
+    : strategy.getTotalScore(currentPlayer) + currentRoundScore
 
   // チェックアウト計算（01モードのみ）
   const checkoutDarts = useMemo(() => {

--- a/src/components/Juno/PlayerSetup.tsx
+++ b/src/components/Juno/PlayerSetup.tsx
@@ -15,7 +15,12 @@ function safeSetItem(key: string, value: string) {
 function loadNameHistory(): string[] {
   try {
     const saved = localStorage.getItem(NAMES_STORAGE_KEY)
-    return saved ? JSON.parse(saved) : []
+    if (!saved) return []
+    const parsed = JSON.parse(saved)
+    if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+      return parsed
+    }
+    return []
   } catch {
     return []
   }
@@ -23,7 +28,8 @@ function loadNameHistory(): string[] {
 
 function saveNameHistory(names: string[]) {
   const history = loadNameHistory()
-  const updated = [...new Set([...names.filter(n => n.trim()), ...history])].slice(0, 20)
+  const trimmedNames = names.map(n => n.trim()).filter(n => n)
+  const updated = [...new Set([...trimmedNames, ...history])].slice(0, 20)
   safeSetItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
 }
 
@@ -238,7 +244,7 @@ export function PlayerSetup({ dispatch }: Props) {
         <label className="block text-sm font-semibold text-gray-400 mb-2">ゲームモード</label>
         <div className="flex gap-2">
           {([['count-up', 'Count Up'], ['zero-one', '01'], ['cricket', 'Cricket']] as const).map(([mode, label]) => {
-            const disabled = mode === 'cricket' && isCricketMode(selectedMode) && playerCount < 2
+            const disabled = mode === 'cricket' && playerCount < 2
             const isSelected = mode === 'cricket' ? (selectedMode === 'cricket' || selectedMode === 'cricket-secret') : selectedMode === mode
             return (
               <button

--- a/src/components/Juno/PlayerSetup.tsx
+++ b/src/components/Juno/PlayerSetup.tsx
@@ -1,0 +1,340 @@
+import { useState, useEffect } from 'react'
+import type { GameAction, GameMode } from '../../types/juno.types'
+
+const NAMES_STORAGE_KEY = 'juno-player-names'
+const LAST_MODE_STORAGE_KEY = 'juno-last-mode'
+const LAST_START_SCORE_STORAGE_KEY = 'juno-last-start-score'
+const LAST_PLAYER_COUNT_STORAGE_KEY = 'juno-last-player-count'
+const LAST_SHUFFLE_STORAGE_KEY = 'juno-last-shuffle'
+
+function loadNameHistory(): string[] {
+  try {
+    const saved = localStorage.getItem(NAMES_STORAGE_KEY)
+    return saved ? JSON.parse(saved) : []
+  } catch {
+    return []
+  }
+}
+
+function saveNameHistory(names: string[]) {
+  const history = loadNameHistory()
+  const updated = [...new Set([...names.filter(n => n.trim()), ...history])].slice(0, 20)
+  localStorage.setItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
+}
+
+function loadLastMode(): GameMode {
+  try {
+    const saved = localStorage.getItem(LAST_MODE_STORAGE_KEY)
+    if (saved && ['count-up', 'zero-one', 'cricket', 'cricket-secret'].includes(saved)) {
+      return saved as GameMode
+    }
+  } catch {}
+  return 'count-up'
+}
+
+function loadLastStartScore(): 301 | 501 | 701 {
+  try {
+    const saved = localStorage.getItem(LAST_START_SCORE_STORAGE_KEY)
+    if (saved && ['301', '501', '701'].includes(saved)) {
+      return Number(saved) as 301 | 501 | 701
+    }
+  } catch {}
+  return 501
+}
+
+function loadLastPlayerCount(): number {
+  try {
+    const saved = localStorage.getItem(LAST_PLAYER_COUNT_STORAGE_KEY)
+    if (saved) {
+      const parsed = Number(saved)
+      if (parsed >= 1 && parsed <= 4) {
+        return parsed
+      }
+    }
+  } catch {}
+  return 2
+}
+
+function removeFromStorageHistory(nameToRemove: string) {
+  const history = loadNameHistory()
+  const updated = history.filter(name => name !== nameToRemove)
+  localStorage.setItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
+}
+
+interface Props {
+  dispatch: React.Dispatch<GameAction>
+}
+
+export function PlayerSetup({ dispatch }: Props) {
+  const [playerCount, setPlayerCount] = useState(loadLastPlayerCount)
+  const [names, setNames] = useState<string[]>(['', '', '', ''])
+  const [nameHistory, setNameHistory] = useState<string[]>([])
+  const [selectedMode, setSelectedMode] = useState<GameMode>(loadLastMode)
+  const [selectedStartScore, setSelectedStartScore] = useState<301 | 501 | 701>(loadLastStartScore)
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
+  const [isCricketSecret, setIsCricketSecret] = useState(loadLastMode() === 'cricket-secret')
+  const [shuffle, setShuffle] = useState(() => localStorage.getItem(LAST_SHUFFLE_STORAGE_KEY) === 'true')
+
+  useEffect(() => {
+    const history = loadNameHistory()
+    setNameHistory(history)
+    if (history.length > 0) {
+      const prefilled = ['', '', '', ''].map((_, i) => history[i] ?? '')
+      setNames(prefilled)
+    }
+  }, [])
+
+  useEffect(() => {
+    setIsCricketSecret(selectedMode === 'cricket-secret')
+  }, [selectedMode])
+
+  const handleStart = () => {
+    let playerNames = names.slice(0, playerCount).map((n, i) => n.trim() || `Player ${i + 1}`)
+    saveNameHistory(names.slice(0, playerCount).filter(n => n.trim()))
+    const gameMode: GameMode = isCricketSecret ? 'cricket-secret' : selectedMode
+    localStorage.setItem(LAST_MODE_STORAGE_KEY, gameMode)
+    localStorage.setItem(LAST_PLAYER_COUNT_STORAGE_KEY, String(playerCount))
+    localStorage.setItem(LAST_SHUFFLE_STORAGE_KEY, String(shuffle))
+    if (gameMode === 'zero-one') {
+      localStorage.setItem(LAST_START_SCORE_STORAGE_KEY, String(selectedStartScore))
+    }
+    if (shuffle) {
+      for (let i = playerNames.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [playerNames[i], playerNames[j]] = [playerNames[j], playerNames[i]]
+      }
+    }
+    dispatch({ type: 'START_GAME', players: playerNames, mode: gameMode, startScore: selectedMode === 'zero-one' ? selectedStartScore : undefined })
+  }
+
+  const handleNameChange = (index: number, value: string) => {
+    const newNames = [...names]
+    newNames[index] = value
+    setNames(newNames)
+  }
+
+  const getSuggestions = (index: number) => {
+    const current = names[index].toLowerCase()
+    const usedNames = names.slice(0, playerCount)
+    if (!current) return nameHistory.filter(h => !usedNames.includes(h)).slice(0, 5)
+    return nameHistory.filter(
+      h => h.toLowerCase().includes(current) && !usedNames.includes(h)
+    ).slice(0, 5)
+  }
+
+  const removeFromHistory = (nameToRemove: string) => {
+    removeFromStorageHistory(nameToRemove)
+    const updated = nameHistory.filter(name => name !== nameToRemove)
+    setNameHistory(updated)
+    // 入力フィールドにその名前が入っていたらクリア
+    const newNames = names.map(n => n === nameToRemove ? '' : n)
+    setNames(newNames)
+  }
+
+  return (
+    <div className="max-w-md mx-auto space-y-8">
+      <div className="text-center">
+        <h1 className="text-5xl font-black text-[#00d4ff] tracking-wider drop-shadow-[0_0_20px_rgba(0,212,255,0.6)]">
+          Juno
+        </h1>
+        <p className="text-gray-500 mt-2 text-sm tracking-widest uppercase">Darts Scorer</p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-semibold text-gray-400 mb-2">プレイヤー人数</label>
+        <div className="flex gap-2">
+          {[1, 2, 3, 4].map((n) => (
+            <button
+              key={n}
+              onClick={() => setPlayerCount(n)}
+              className={`flex-1 py-3 rounded-xl font-bold text-lg transition-all ${
+                playerCount === n
+                  ? 'bg-[#00d4ff] text-[#0a0a0a] shadow-[0_0_15px_rgba(0,212,255,0.4)]'
+                  : 'bg-[#1a1a2e] text-gray-400 hover:bg-[#252547] border border-[#2a2a4a]'
+              }`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="block text-sm font-semibold text-gray-400">プレイヤー名</label>
+        {Array.from({ length: playerCount }, (_, i) => {
+          const usedNames = names.slice(0, playerCount).filter(n => n.trim())
+          const suggestions = getSuggestions(i)
+          const showDropdown = focusedIndex === i && suggestions.length > 0
+
+          return (
+            <div key={i} className="relative">
+              <input
+                type="text"
+                value={names[i]}
+                onChange={(e) => handleNameChange(i, e.target.value)}
+                onFocus={() => setFocusedIndex(i)}
+                onBlur={() => setFocusedIndex(null)}
+                placeholder={`Player ${i + 1}`}
+                className="w-full px-4 pr-10 py-3 bg-[#1a1a2e] border border-[#2a2a4a] rounded-xl text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-[#00d4ff]/50 focus:border-[#00d4ff] relative z-10"
+                autoFocus={false}
+              />
+
+              {names[i] && (
+                <button
+                  type="button"
+                  onClick={() => handleNameChange(i, '')}
+                  onMouseDown={(e) => e.preventDefault()}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white transition-colors z-20"
+                >
+                  ✕
+                </button>
+              )}
+
+              {showDropdown && (
+                <div className="absolute top-full left-0 right-0 mt-1 bg-[#1a1a2e] border border-[#2a2a4a] rounded-xl overflow-hidden z-50 shadow-lg">
+                  {suggestions.map((name) => (
+                    <div
+                      key={name}
+                      className="w-full px-4 py-2 flex justify-between items-center text-white hover:bg-[#252547] transition-colors group"
+                    >
+                      <button
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => {
+                          handleNameChange(i, name)
+                          setFocusedIndex(null)
+                        }}
+                        className="flex-1 text-left"
+                      >
+                        {name}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          removeFromHistory(name)
+                        }}
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                        }}
+                        className="text-gray-500 hover:text-red-400 active:text-red-400 transition-colors ml-2 flex-shrink-0"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div>
+        <label className="block text-sm font-semibold text-gray-400 mb-2">ゲームモード</label>
+        <div className="flex gap-2">
+          {([['count-up', 'Count Up'], ['zero-one', '01'], ['cricket', 'Cricket']] as const).map(([mode, label]) => {
+            const disabled = mode === 'cricket' && playerCount < 2
+            const isSelected = mode === 'cricket' ? (selectedMode === 'cricket' || selectedMode === 'cricket-secret') : selectedMode === mode
+            return (
+              <button
+                key={mode}
+                onClick={() => {
+                  if (!disabled) {
+                    if (mode === 'cricket') {
+                      setSelectedMode('cricket')
+                      setIsCricketSecret(false)
+                    } else {
+                      setSelectedMode(mode)
+                    }
+                  }
+                }}
+                className={`flex-1 py-3 rounded-xl font-bold transition-all ${
+                  disabled
+                    ? 'bg-[#1a1a2e] text-gray-600 border border-[#2a2a4a] cursor-not-allowed'
+                    : isSelected
+                    ? 'bg-[#00d4ff] text-[#0a0a0a] shadow-[0_0_15px_rgba(0,212,255,0.4)]'
+                    : 'bg-[#1a1a2e] text-gray-400 hover:bg-[#252547] border border-[#2a2a4a]'
+                }`}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+        {selectedMode === 'zero-one' && (
+          <div className="flex gap-2 mt-2">
+            {([301, 501, 701] as const).map((score) => (
+              <button
+                key={score}
+                onClick={() => setSelectedStartScore(score)}
+                className={`flex-1 py-2 rounded-xl font-bold transition-all ${
+                  selectedStartScore === score
+                    ? 'bg-[#00d4ff] text-[#0a0a0a] shadow-[0_0_15px_rgba(0,212,255,0.4)]'
+                    : 'bg-[#1a1a2e] text-gray-400 hover:bg-[#252547] border border-[#2a2a4a]'
+                }`}
+              >
+                {score}
+              </button>
+            ))}
+          </div>
+        )}
+        {(selectedMode === 'cricket' || selectedMode === 'cricket-secret') && (
+          <div className="flex gap-2 mt-2">
+            {(['normal', 'secret'] as const).map((variant) => (
+              <button
+                key={variant}
+                onClick={() => {
+                  if (variant === 'normal') {
+                    setSelectedMode('cricket')
+                    setIsCricketSecret(false)
+                  } else {
+                    setSelectedMode('cricket-secret')
+                    setIsCricketSecret(true)
+                  }
+                }}
+                className={`flex-1 py-2 rounded-xl font-bold transition-all ${
+                  (variant === 'normal' && selectedMode === 'cricket') || (variant === 'secret' && selectedMode === 'cricket-secret')
+                    ? 'bg-[#00d4ff] text-[#0a0a0a] shadow-[0_0_15px_rgba(0,212,255,0.4)]'
+                    : 'bg-[#1a1a2e] text-gray-400 hover:bg-[#252547] border border-[#2a2a4a]'
+                }`}
+              >
+                {variant === 'normal' ? 'Normal' : 'Secret'}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between px-1">
+        <span className="text-sm font-semibold text-gray-400">順番をシャッフル</span>
+        <button
+          type="button"
+          onClick={() => setShuffle(!shuffle)}
+          className={`relative w-11 h-6 rounded-full transition-colors ${
+            shuffle ? 'bg-[#00d4ff]' : 'bg-[#333]'
+          }`}
+        >
+          <div
+            className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
+              shuffle ? 'translate-x-5' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
+      <button
+        onClick={handleStart}
+        disabled={selectedMode === 'cricket' && playerCount < 2 || selectedMode === 'cricket-secret' && playerCount < 2}
+        className={`w-full py-4 rounded-xl font-bold text-lg transition-all ${
+          (selectedMode === 'cricket' || selectedMode === 'cricket-secret') && playerCount < 2
+            ? 'bg-[#1a1a2e] text-gray-600 border border-[#2a2a4a] cursor-not-allowed'
+            : 'bg-[#00d4ff] text-[#0a0a0a] hover:bg-[#00b8d9] active:bg-[#009db8] shadow-[0_0_25px_rgba(0,212,255,0.4)] hover:shadow-[0_0_35px_rgba(0,212,255,0.6)]'
+        }`}
+      >
+        ゲーム開始
+      </button>
+    </div>
+  )
+}

--- a/src/components/Juno/PlayerSetup.tsx
+++ b/src/components/Juno/PlayerSetup.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { GameAction, GameMode } from '../../types/juno.types'
+import { isCricketMode } from '../../types/juno.types'
 
 const NAMES_STORAGE_KEY = 'juno-player-names'
 const LAST_MODE_STORAGE_KEY = 'juno-last-mode'
@@ -76,10 +77,11 @@ export function PlayerSetup({ dispatch }: Props) {
   const [selectedMode, setSelectedMode] = useState<GameMode>(loadLastMode)
   const [selectedStartScore, setSelectedStartScore] = useState<301 | 501 | 701>(loadLastStartScore)
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
-  const [isCricketSecret, setIsCricketSecret] = useState(loadLastMode() === 'cricket-secret')
   const [shuffle, setShuffle] = useState(() => {
     try { return localStorage.getItem(LAST_SHUFFLE_STORAGE_KEY) === 'true' } catch { return false }
   })
+
+  const isCricketSecret = selectedMode === 'cricket-secret'
 
   useEffect(() => {
     const history = loadNameHistory()
@@ -89,10 +91,6 @@ export function PlayerSetup({ dispatch }: Props) {
       setNames(prefilled)
     }
   }, [])
-
-  useEffect(() => {
-    setIsCricketSecret(selectedMode === 'cricket-secret')
-  }, [selectedMode])
 
   const handleStart = () => {
     let playerNames = names.slice(0, playerCount).map((n, i) => n.trim() || `Player ${i + 1}`)
@@ -240,19 +238,14 @@ export function PlayerSetup({ dispatch }: Props) {
         <label className="block text-sm font-semibold text-gray-400 mb-2">ゲームモード</label>
         <div className="flex gap-2">
           {([['count-up', 'Count Up'], ['zero-one', '01'], ['cricket', 'Cricket']] as const).map(([mode, label]) => {
-            const disabled = mode === 'cricket' && playerCount < 2
+            const disabled = mode === 'cricket' && isCricketMode(selectedMode) && playerCount < 2
             const isSelected = mode === 'cricket' ? (selectedMode === 'cricket' || selectedMode === 'cricket-secret') : selectedMode === mode
             return (
               <button
                 key={mode}
                 onClick={() => {
                   if (!disabled) {
-                    if (mode === 'cricket') {
-                      setSelectedMode('cricket')
-                      setIsCricketSecret(false)
-                    } else {
-                      setSelectedMode(mode)
-                    }
+                    setSelectedMode(mode === 'cricket' ? 'cricket' : mode)
                   }
                 }}
                 className={`flex-1 py-3 rounded-xl font-bold transition-all ${
@@ -293,10 +286,8 @@ export function PlayerSetup({ dispatch }: Props) {
                 onClick={() => {
                   if (variant === 'normal') {
                     setSelectedMode('cricket')
-                    setIsCricketSecret(false)
                   } else {
                     setSelectedMode('cricket-secret')
-                    setIsCricketSecret(true)
                   }
                 }}
                 className={`flex-1 py-2 rounded-xl font-bold transition-all ${
@@ -331,9 +322,9 @@ export function PlayerSetup({ dispatch }: Props) {
 
       <button
         onClick={handleStart}
-        disabled={selectedMode === 'cricket' && playerCount < 2 || selectedMode === 'cricket-secret' && playerCount < 2}
+        disabled={isCricketMode(selectedMode) && playerCount < 2}
         className={`w-full py-4 rounded-xl font-bold text-lg transition-all ${
-          (selectedMode === 'cricket' || selectedMode === 'cricket-secret') && playerCount < 2
+          isCricketMode(selectedMode) && playerCount < 2
             ? 'bg-[#1a1a2e] text-gray-600 border border-[#2a2a4a] cursor-not-allowed'
             : 'bg-[#00d4ff] text-[#0a0a0a] hover:bg-[#00b8d9] active:bg-[#009db8] shadow-[0_0_25px_rgba(0,212,255,0.4)] hover:shadow-[0_0_35px_rgba(0,212,255,0.6)]'
         }`}

--- a/src/components/Juno/PlayerSetup.tsx
+++ b/src/components/Juno/PlayerSetup.tsx
@@ -7,6 +7,10 @@ const LAST_START_SCORE_STORAGE_KEY = 'juno-last-start-score'
 const LAST_PLAYER_COUNT_STORAGE_KEY = 'juno-last-player-count'
 const LAST_SHUFFLE_STORAGE_KEY = 'juno-last-shuffle'
 
+function safeSetItem(key: string, value: string) {
+  try { localStorage.setItem(key, value) } catch {}
+}
+
 function loadNameHistory(): string[] {
   try {
     const saved = localStorage.getItem(NAMES_STORAGE_KEY)
@@ -19,7 +23,7 @@ function loadNameHistory(): string[] {
 function saveNameHistory(names: string[]) {
   const history = loadNameHistory()
   const updated = [...new Set([...names.filter(n => n.trim()), ...history])].slice(0, 20)
-  localStorage.setItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
+  safeSetItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
 }
 
 function loadLastMode(): GameMode {
@@ -58,7 +62,7 @@ function loadLastPlayerCount(): number {
 function removeFromStorageHistory(nameToRemove: string) {
   const history = loadNameHistory()
   const updated = history.filter(name => name !== nameToRemove)
-  localStorage.setItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
+  safeSetItem(NAMES_STORAGE_KEY, JSON.stringify(updated))
 }
 
 interface Props {
@@ -73,7 +77,9 @@ export function PlayerSetup({ dispatch }: Props) {
   const [selectedStartScore, setSelectedStartScore] = useState<301 | 501 | 701>(loadLastStartScore)
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
   const [isCricketSecret, setIsCricketSecret] = useState(loadLastMode() === 'cricket-secret')
-  const [shuffle, setShuffle] = useState(() => localStorage.getItem(LAST_SHUFFLE_STORAGE_KEY) === 'true')
+  const [shuffle, setShuffle] = useState(() => {
+    try { return localStorage.getItem(LAST_SHUFFLE_STORAGE_KEY) === 'true' } catch { return false }
+  })
 
   useEffect(() => {
     const history = loadNameHistory()
@@ -92,11 +98,11 @@ export function PlayerSetup({ dispatch }: Props) {
     let playerNames = names.slice(0, playerCount).map((n, i) => n.trim() || `Player ${i + 1}`)
     saveNameHistory(names.slice(0, playerCount).filter(n => n.trim()))
     const gameMode: GameMode = isCricketSecret ? 'cricket-secret' : selectedMode
-    localStorage.setItem(LAST_MODE_STORAGE_KEY, gameMode)
-    localStorage.setItem(LAST_PLAYER_COUNT_STORAGE_KEY, String(playerCount))
-    localStorage.setItem(LAST_SHUFFLE_STORAGE_KEY, String(shuffle))
+    safeSetItem(LAST_MODE_STORAGE_KEY, gameMode)
+    safeSetItem(LAST_PLAYER_COUNT_STORAGE_KEY, String(playerCount))
+    safeSetItem(LAST_SHUFFLE_STORAGE_KEY, String(shuffle))
     if (gameMode === 'zero-one') {
-      localStorage.setItem(LAST_START_SCORE_STORAGE_KEY, String(selectedStartScore))
+      safeSetItem(LAST_START_SCORE_STORAGE_KEY, String(selectedStartScore))
     }
     if (shuffle) {
       for (let i = playerNames.length - 1; i > 0; i--) {
@@ -162,7 +168,6 @@ export function PlayerSetup({ dispatch }: Props) {
       <div className="space-y-3">
         <label className="block text-sm font-semibold text-gray-400">プレイヤー名</label>
         {Array.from({ length: playerCount }, (_, i) => {
-          const usedNames = names.slice(0, playerCount).filter(n => n.trim())
           const suggestions = getSuggestions(i)
           const showDropdown = focusedIndex === i && suggestions.length > 0
 

--- a/src/components/Juno/ResultView.tsx
+++ b/src/components/Juno/ResultView.tsx
@@ -1,0 +1,124 @@
+import type { GameState, GameAction, GameModeStrategy } from '../../types/juno.types'
+
+interface Props {
+  state: GameState
+  strategy: GameModeStrategy
+  dispatch: React.Dispatch<GameAction>
+}
+
+function getModeName(state: GameState): string {
+  if (state.mode === 'zero-one') return `01 - ${state.startScore ?? 501}`
+  if (state.mode === 'cricket') return 'Cricket'
+  if (state.mode === 'cricket-secret') return 'Secret Cricket'
+  return 'Count Up'
+}
+
+export function ResultView({ state, strategy, dispatch }: Props) {
+  const rankings = (state.mode === 'cricket' || state.mode === 'cricket-secret') && state.cricketScores
+    ? state.players
+        .map((_, i) => ({ playerIndex: i, score: state.cricketScores![i] ?? 0, rank: 0 }))
+        .sort((a, b) => {
+          // プレイヤー人数に応じてソート順を変更
+          if (state.players.length === 2) {
+            // タイマン: 最高スコア（降順）が上位
+            return b.score - a.score
+          } else {
+            // カットスロート: 最低スコア（昇順）が上位
+            return a.score - b.score
+          }
+        })
+        .map((r, i, arr) => ({
+          ...r,
+          rank: i === 0 || arr[i - 1].score !== r.score ? i + 1 : arr[i - 1].rank,
+        }))
+    : strategy.getRankings(state.players)
+
+  const handleRematch = () => {
+    dispatch({ type: 'START_GAME', players: state.players.map(p => p.name), mode: state.mode, startScore: state.startScore })
+  }
+
+  return (
+    <div className="max-w-md mx-auto space-y-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-black text-[#00d4ff] tracking-wider drop-shadow-[0_0_15px_rgba(0,212,255,0.5)]">
+          結果
+        </h2>
+        <p className="text-gray-500 text-sm tracking-widest uppercase">
+          {getModeName(state)}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {rankings.map((r) => {
+          const player = state.players[r.playerIndex]
+          const isFirst = r.rank === 1
+
+          // 表示スコアの計算
+          let displayScore: number
+          if (state.mode === 'zero-one') {
+            displayScore = (state.startScore ?? 501) - r.score
+          } else if (state.mode === 'cricket' || state.mode === 'cricket-secret') {
+            displayScore = r.score
+          } else {
+            displayScore = r.score
+          }
+
+          return (
+            <div
+              key={r.playerIndex}
+              className={`p-4 rounded-xl ${
+                isFirst
+                  ? 'bg-gradient-to-r from-[#2a2000] to-[#1a1a2e] border-2 border-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.3)]'
+                  : 'bg-[#1a1a2e] border border-[#2a2a4a]'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className={`text-2xl font-black ${
+                    isFirst
+                      ? 'text-yellow-400 drop-shadow-[0_0_8px_rgba(234,179,8,0.6)]'
+                      : 'text-gray-600'
+                  }`}>
+                    {r.rank}
+                  </span>
+                  <span className="font-semibold text-white text-lg">{player.name}</span>
+                </div>
+                <span className={`text-3xl font-black ${
+                  isFirst
+                    ? 'text-yellow-400 drop-shadow-[0_0_10px_rgba(234,179,8,0.6)]'
+                    : 'text-[#00d4ff] drop-shadow-[0_0_6px_rgba(0,212,255,0.4)]'
+                }`}>
+                  {displayScore}
+                </span>
+              </div>
+              {state.mode !== 'cricket' && state.mode !== 'cricket-secret' && (
+                <div className="mt-2 flex gap-1 flex-wrap">
+                  {player.rounds.map((round, rIdx) => (
+                    <span key={rIdx} className="text-xs px-2 py-0.5 bg-[#252547] rounded text-gray-400">
+                      R{rIdx + 1}: {strategy.calculateRoundScore(round)}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={handleRematch}
+          className="flex-1 py-3 bg-[#00d4ff] text-[#0a0a0a] rounded-xl font-bold hover:bg-[#00b8d9] transition-all shadow-[0_0_15px_rgba(0,212,255,0.3)]"
+        >
+          もう一度
+        </button>
+        <button
+          onClick={() => dispatch({ type: 'RESET_GAME' })}
+          className="flex-1 py-3 bg-[#1a1a2e] text-gray-400 rounded-xl font-bold hover:bg-[#252547] transition-colors border border-[#2a2a4a]"
+        >
+          セットアップに戻る
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Juno/RoundIndicator.tsx
+++ b/src/components/Juno/RoundIndicator.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  currentRound: number
+  maxRounds: number
+  currentPlayerName: string
+  throwCount: number
+}
+
+export function RoundIndicator({ currentRound, maxRounds, currentPlayerName, throwCount }: Props) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <div className="font-semibold text-gray-400">
+        Round <span className="text-[#00d4ff] text-lg drop-shadow-[0_0_6px_rgba(0,212,255,0.4)]">{currentRound + 1}</span>
+        <span className="text-gray-600"> / {maxRounds}</span>
+      </div>
+      <div className="font-semibold text-[#00d4ff]">
+        {currentPlayerName} — {throwCount}/3投
+      </div>
+    </div>
+  )
+}

--- a/src/components/Juno/ScoreBoard.tsx
+++ b/src/components/Juno/ScoreBoard.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react'
+import type { GameState, GameModeStrategy } from '../../types/juno.types'
+import { ChevronRight } from 'lucide-react'
+import { getThrowScore } from '../../types/juno.types'
+
+interface Props {
+  state: GameState
+  strategy: GameModeStrategy
+}
+
+export function ScoreBoard({ state, strategy }: Props) {
+  const currentRoundRef = useRef<HTMLTableCellElement>(null)
+
+  useEffect(() => {
+    currentRoundRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+  }, [state.currentRound])
+
+  return (
+    <div className="bg-[#1a1a2e] rounded-xl shadow-sm overflow-x-auto border border-[#333]">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-[#252547]">
+            <th className="py-2 px-3 text-left font-semibold text-gray-400 sticky left-0 bg-[#252547]">Player</th>
+            {Array.from({ length: state.maxRounds }, (_, i) => (
+              <th
+                key={i}
+                ref={i === state.currentRound ? currentRoundRef : undefined}
+                className={`py-2 px-2 text-center font-semibold ${
+                  i === state.currentRound ? 'text-[#00d4ff] bg-[#00d4ff]/10' : 'text-gray-500'
+                }`}
+              >
+                R{i + 1}
+              </th>
+            ))}
+            <th className="py-2 px-3 text-center font-bold text-gray-300">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.players.map((player, pIdx) => {
+            const isCurrentPlayer = state.phase === 'playing' && pIdx === state.currentPlayerIndex
+            return (
+              <tr key={pIdx} className={isCurrentPlayer ? 'bg-[#00d4ff]/10' : ''}>
+                <td className={`py-2 px-3 font-semibold sticky left-0 whitespace-nowrap ${isCurrentPlayer ? 'text-[#00d4ff] bg-[#00d4ff]/10' : 'text-gray-300 bg-[#1a1a2e]'}`}>
+                  {isCurrentPlayer && <ChevronRight size={14} className="inline mr-0.5 text-[#00d4ff]" />}
+                  {player.name}
+                </td>
+                {Array.from({ length: state.maxRounds }, (_, rIdx) => {
+                  const round = player.rounds[rIdx]
+                  const isCurrentRoundForPlayer = isCurrentPlayer && rIdx === state.currentRound && !round && state.currentThrows.length > 0
+                  const roundScore = round
+                    ? strategy.calculateRoundScore(round)
+                    : isCurrentRoundForPlayer
+                      ? strategy.calculateRoundScore(state.currentThrows)
+                      : null
+                  return (
+                    <td key={rIdx} className={`py-2 px-2 text-center ${
+                      rIdx === state.currentRound ? 'bg-[#00d4ff]/5' : ''
+                    }`}>
+                      {roundScore !== null ? (
+                        <span className={`font-mono ${isCurrentRoundForPlayer ? 'text-[#00d4ff]' : 'text-gray-300'}`}>{roundScore}</span>
+                      ) : (
+                        <span className="text-gray-600">-</span>
+                      )}
+                    </td>
+                  )
+                })}
+                <td className="py-2 px-3 text-center font-bold font-mono text-white">
+                  {(() => {
+                    const currentThrowsScore = isCurrentPlayer ? state.currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0) : 0
+                    const totalWithCurrent = strategy.getTotalScore(player) + currentThrowsScore
+                    return state.mode === 'zero-one'
+                      ? (state.startScore ?? 501) - totalWithCurrent
+                      : totalWithCurrent
+                  })()}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/Juno/SegmentSelector.tsx
+++ b/src/components/Juno/SegmentSelector.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import type { DartNumber, DartThrow } from '../../types/juno.types'
+import { BOARD_NUMBERS } from '../../data/dartboard'
+
+interface Props {
+  onSelect: (dart: DartThrow) => void
+  disabled?: boolean
+}
+
+export function SegmentSelector({ onSelect, disabled }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedNumber, setSelectedNumber] = useState<DartNumber | null>(null)
+
+  const handleMultiplierClick = (multiplier: 'single' | 'double' | 'triple') => {
+    if (!selectedNumber) return
+    if (selectedNumber === 25 && multiplier === 'triple') return
+    onSelect({ number: selectedNumber, multiplier })
+    setSelectedNumber(null)
+  }
+
+  const handleMiss = () => {
+    onSelect('miss')
+    setSelectedNumber(null)
+  }
+
+  return (
+    <div className={disabled ? 'pointer-events-none opacity-50' : ''}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="text-sm text-gray-500 hover:text-[#00d4ff] underline transition-colors"
+      >
+        {isOpen ? 'ボタン入力を閉じる' : 'ボタン入力を開く'}
+      </button>
+
+      {isOpen && (
+        <div className="mt-3 p-4 bg-[#1a1a2e] rounded-xl space-y-3 border border-[#333]">
+          {selectedNumber === null ? (
+            <>
+              <p className="text-sm text-gray-400 font-semibold">数字を選択</p>
+              <div className="grid grid-cols-7 gap-1.5">
+                {BOARD_NUMBERS.map((num) => (
+                  <button
+                    key={num}
+                    onClick={() => setSelectedNumber(num)}
+                    className="py-2 bg-[#252547] border border-[#444] rounded-lg text-sm font-semibold text-gray-300 hover:bg-[#00d4ff]/20 hover:border-[#00d4ff] active:bg-[#00d4ff]/30 transition-colors"
+                  >
+                    {num}
+                  </button>
+                ))}
+                <button
+                  onClick={() => setSelectedNumber(25)}
+                  className="col-span-2 py-2 bg-[#252547] border border-[#444] rounded-lg text-sm font-semibold text-gray-300 hover:bg-[#00d4ff]/20 hover:border-[#00d4ff] active:bg-[#00d4ff]/30 transition-colors"
+                >
+                  BULL
+                </button>
+                <button
+                  onClick={handleMiss}
+                  className="col-span-2 py-2 bg-[#252547] border border-[#444] rounded-lg text-sm font-semibold text-gray-400 hover:bg-[#333] transition-colors"
+                >
+                  MISS
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <p className="text-sm text-gray-400 font-semibold">
+                  {selectedNumber === 25 ? 'BULL' : selectedNumber} の倍率
+                </p>
+                <button
+                  onClick={() => setSelectedNumber(null)}
+                  className="text-xs text-gray-500 hover:text-[#00d4ff] underline"
+                >
+                  戻る
+                </button>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleMultiplierClick('single')}
+                  className="flex-1 py-3 bg-[#252547] border-2 border-[#444] rounded-lg font-bold text-gray-300 hover:bg-[#333] active:bg-[#3a3a5e] transition-colors"
+                >
+                  {selectedNumber === 25 ? 'OUTER BULL (25)' : `S${selectedNumber} (${selectedNumber})`}
+                </button>
+                <button
+                  onClick={() => handleMultiplierClick('double')}
+                  className="flex-1 py-3 bg-[#ff3366]/10 border-2 border-[#ff3366] rounded-lg font-bold text-[#ff3366] hover:bg-[#ff3366]/20 active:bg-[#ff3366]/30 transition-colors"
+                >
+                  {selectedNumber === 25 ? 'BULL (50)' : `D${selectedNumber} (${selectedNumber * 2})`}
+                </button>
+                {selectedNumber !== 25 && (
+                  <button
+                    onClick={() => handleMultiplierClick('triple')}
+                    className="flex-1 py-3 bg-[#00ff88]/10 border-2 border-[#00ff88] rounded-lg font-bold text-[#00ff88] hover:bg-[#00ff88]/20 active:bg-[#00ff88]/30 transition-colors"
+                  >
+                    {`T${selectedNumber} (${selectedNumber * 3})`}
+                  </button>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Juno/ThrowHistory.tsx
+++ b/src/components/Juno/ThrowHistory.tsx
@@ -1,0 +1,70 @@
+import { formatThrow, getThrowScore, type DartThrow } from '../../types/juno.types'
+import { Undo2 } from 'lucide-react'
+
+interface Props {
+  throws: DartThrow[]
+  onUndo: () => void
+  canUndo: boolean
+  isCricket?: boolean
+  secretNumbers?: number[]
+}
+
+export function ThrowHistory({ throws, onUndo, canUndo, isCricket, secretNumbers }: Props) {
+  const roundScore = throws.reduce((sum, t) => sum + getThrowScore(t), 0)
+
+  // シークレットCricketでハズレかどうかを判定
+  const isSecretMiss = (t: DartThrow): boolean => {
+    if (secretNumbers === undefined) return false
+    if (t === 'miss') return false
+    return !secretNumbers.includes(t.number)
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {[0, 1, 2].map((i) => {
+        const t = throws[i]
+        return (
+          <div
+            key={i}
+            className={`flex-1 h-11 rounded-xl flex items-center justify-center font-bold text-sm border-2 transition-colors ${
+              t !== undefined
+                ? (isSecretMiss(t)
+                    ? 'bg-[#1a1a2e] border-[#555] text-gray-500'
+                    : 'bg-[#00d4ff]/20 border-[#00d4ff] text-white')
+                : i === throws.length
+                  ? 'border-[#00d4ff] border-dashed text-[#00d4ff]'
+                  : 'border-[#333] bg-[#1a1a2e] text-gray-600'
+            }`}
+          >
+            {t !== undefined ? (
+              <div className="text-center">
+                <div style={isSecretMiss(t) ? {} : { textShadow: '0 0 8px #00d4ff' }}>
+                  {formatThrow(t)}
+                </div>
+                {!isCricket && <div className="text-xs text-gray-400">{getThrowScore(t)}pt</div>}
+              </div>
+            ) : (
+              i === throws.length ? '?' : '-'
+            )}
+          </div>
+        )
+      })}
+      <div className="w-16 text-center">
+        <div className="text-xs text-gray-500">計</div>
+        <div
+          className="text-xl font-bold font-mono text-white"
+          style={{ textShadow: '0 0 10px #00d4ff' }}
+        >
+          {roundScore}
+        </div>
+      </div>
+      <button
+        onClick={onUndo}
+        disabled={!canUndo}
+        className="px-3 py-2 text-sm bg-[#252547] text-gray-400 rounded-lg hover:bg-[#333] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      >
+        <Undo2 size={16} />
+      </button>
+    </div>
+  )
+}

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -13,11 +13,15 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID
 };
 
-// Firebaseアプリの初期化（API keyが未設定の場合はスキップ）
-const app = firebaseConfig.apiKey ? initializeApp(firebaseConfig) : null;
+// Firebaseアプリの初期化（API keyが未設定の場合はthrow）
+if (!firebaseConfig.apiKey) {
+  throw new Error('Firebase設定が見つかりません。.envファイルを確認してください。');
+}
+
+const app = initializeApp(firebaseConfig);
 
 // 認証の初期化
-export const auth = app ? getAuth(app) : null;
+export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
 
 // Google Providerにスコープを追加してプロフィール情報を確実に取得
@@ -28,9 +32,4 @@ googleProvider.setCustomParameters({
 });
 
 // Firestoreの初期化
-export const db = app ? getFirestore(app) : null;
-
-// エラーハンドリング
-if (!firebaseConfig.apiKey) {
-  console.error('Firebase設定が見つかりません。.envファイルを確認してください。');
-}
+export const db = getFirestore(app);

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -13,11 +13,11 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID
 };
 
-// Firebaseアプリの初期化
-const app = initializeApp(firebaseConfig);
+// Firebaseアプリの初期化（API keyが未設定の場合はスキップ）
+const app = firebaseConfig.apiKey ? initializeApp(firebaseConfig) : null;
 
 // 認証の初期化
-export const auth = getAuth(app);
+export const auth = app ? getAuth(app) : null;
 export const googleProvider = new GoogleAuthProvider();
 
 // Google Providerにスコープを追加してプロフィール情報を確実に取得
@@ -28,7 +28,7 @@ googleProvider.setCustomParameters({
 });
 
 // Firestoreの初期化
-export const db = getFirestore(app);
+export const db = app ? getFirestore(app) : null;
 
 // エラーハンドリング
 if (!firebaseConfig.apiKey) {

--- a/src/data/dartboard.ts
+++ b/src/data/dartboard.ts
@@ -1,0 +1,148 @@
+import type { DartNumber, Multiplier, Segment } from '../types/juno.types'
+
+export const BOARD_CENTER = 220
+export const BOARD_SIZE = 440
+
+export const RADIUS = {
+  bullseye: 18,
+  outerBull: 42,
+  innerSingle: 100,
+  triple: 108,
+  outerTriple: 130,
+  outerSingle: 170,
+  double: 175,
+  outerDouble: 192,
+  missRing: 220,
+} as const
+
+export const BOARD_NUMBERS: DartNumber[] = [
+  20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5
+]
+
+const SEGMENT_ANGLE = 360 / 20
+
+function polarToCartesian(cx: number, cy: number, r: number, angleDeg: number) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad),
+  }
+}
+
+function arcPath(cx: number, cy: number, rInner: number, rOuter: number, startAngle: number, endAngle: number): string {
+  const s1 = polarToCartesian(cx, cy, rOuter, startAngle)
+  const e1 = polarToCartesian(cx, cy, rOuter, endAngle)
+  const s2 = polarToCartesian(cx, cy, rInner, endAngle)
+  const e2 = polarToCartesian(cx, cy, rInner, startAngle)
+  const largeArc = endAngle - startAngle > 180 ? 1 : 0
+  return [
+    `M ${s1.x} ${s1.y}`,
+    `A ${rOuter} ${rOuter} 0 ${largeArc} 1 ${e1.x} ${e1.y}`,
+    `L ${s2.x} ${s2.y}`,
+    `A ${rInner} ${rInner} 0 ${largeArc} 0 ${e2.x} ${e2.y}`,
+    'Z',
+  ].join(' ')
+}
+
+function circlePath(cx: number, cy: number, r: number): string {
+  return `M ${cx - r} ${cy} A ${r} ${r} 0 1 0 ${cx + r} ${cy} A ${r} ${r} 0 1 0 ${cx - r} ${cy} Z`
+}
+
+function ringPath(cx: number, cy: number, rInner: number, rOuter: number): string {
+  // 外側リング（時計回り）
+  // 内側リング（反時計回り）で穴を開ける
+  return [
+    `M ${cx - rOuter} ${cy}`,
+    `A ${rOuter} ${rOuter} 0 1 0 ${cx + rOuter} ${cy}`,
+    `A ${rOuter} ${rOuter} 0 1 0 ${cx - rOuter} ${cy}`,
+    'Z',
+    `M ${cx - rInner} ${cy}`,
+    `A ${rInner} ${rInner} 0 1 1 ${cx + rInner} ${cy}`,
+    `A ${rInner} ${rInner} 0 1 1 ${cx - rInner} ${cy}`,
+    'Z',
+  ].join(' ')
+}
+
+export interface SegmentPath {
+  d: string
+  segment: Segment | 'miss'
+  boardIndex: number
+}
+
+export function generateBoardPaths(): SegmentPath[] {
+  const cx = BOARD_CENTER
+  const cy = BOARD_CENTER
+  const paths: SegmentPath[] = []
+
+  paths.push({
+    d: circlePath(cx, cy, RADIUS.bullseye),
+    segment: { number: 25, multiplier: 'double' },
+    boardIndex: -1,
+  })
+
+  paths.push({
+    d: ringPath(cx, cy, RADIUS.bullseye, RADIUS.outerBull),
+    segment: { number: 25, multiplier: 'single' },
+    boardIndex: -1,
+  })
+
+  for (let i = 0; i < 20; i++) {
+    const num = BOARD_NUMBERS[i]
+    const startAngle = i * SEGMENT_ANGLE - SEGMENT_ANGLE / 2
+    const endAngle = startAngle + SEGMENT_ANGLE
+
+    paths.push({
+      d: arcPath(cx, cy, RADIUS.outerBull, RADIUS.triple, startAngle, endAngle),
+      segment: { number: num, multiplier: 'single' },
+      boardIndex: i,
+    })
+
+    paths.push({
+      d: arcPath(cx, cy, RADIUS.triple, RADIUS.outerTriple, startAngle, endAngle),
+      segment: { number: num, multiplier: 'triple' },
+      boardIndex: i,
+    })
+
+    paths.push({
+      d: arcPath(cx, cy, RADIUS.outerTriple, RADIUS.double, startAngle, endAngle),
+      segment: { number: num, multiplier: 'single' },
+      boardIndex: i,
+    })
+
+    paths.push({
+      d: arcPath(cx, cy, RADIUS.double, RADIUS.outerDouble, startAngle, endAngle),
+      segment: { number: num, multiplier: 'double' },
+      boardIndex: i,
+    })
+  }
+
+  // MISSリング（ダブルリングの外側）
+  paths.push({
+    d: ringPath(cx, cy, RADIUS.outerDouble, RADIUS.missRing),
+    segment: 'miss',
+    boardIndex: -1,
+  })
+
+  return paths
+}
+
+export function getSegmentColor(boardIndex: number, multiplier: Multiplier, number: DartNumber): string {
+  // DARTSLIVE風: 赤/青(ダブル・トリプル)、黒/白(シングル)
+  if (number === 25) {
+    return multiplier === 'double' ? '#E83535' : '#1565C0'
+  }
+  const isEven = boardIndex % 2 === 0
+  if (multiplier === 'double' || multiplier === 'triple') {
+    return isEven ? '#E83535' : '#1565C0'
+  }
+  return isEven ? '#1A1A1A' : '#F0F0E8'
+}
+
+export function getNumberLabelPositions(): { x: number; y: number; number: DartNumber }[] {
+  const labelRadius = RADIUS.outerDouble + 15
+  return BOARD_NUMBERS.map((num, i) => {
+    const angle = i * SEGMENT_ANGLE
+    const pos = polarToCartesian(BOARD_CENTER, BOARD_CENTER, labelRadius, angle)
+    return { ...pos, number: num }
+  })
+}

--- a/src/data/gameModes.ts
+++ b/src/data/gameModes.ts
@@ -1,0 +1,205 @@
+import { getThrowScore, type DartThrow, type GameModeStrategy, type GameState, type PlayerState } from '../types/juno.types'
+
+export const CRICKET_NUMBERS = [20, 19, 18, 17, 16, 15, 25]
+
+const countUpStrategy: GameModeStrategy = {
+  maxRounds: 8,
+
+  calculateRoundScore(throws: DartThrow[]): number {
+    return throws.reduce((sum, t) => sum + getThrowScore(t), 0)
+  },
+
+  getTotalScore(player: PlayerState): number {
+    return player.rounds.reduce(
+      (sum, round) => sum + round.reduce((s, t) => s + getThrowScore(t), 0),
+      0
+    )
+  },
+
+  isGameOver(state: GameState): boolean {
+    return state.currentRound >= this.maxRounds && state.currentPlayerIndex === 0 && state.currentThrows.length === 0
+  },
+
+  getRankings(players: PlayerState[]): { playerIndex: number; rank: number; score: number }[] {
+    const scores = players.map((p, i) => ({
+      playerIndex: i,
+      score: this.getTotalScore(p),
+      rank: 0,
+    }))
+    scores.sort((a, b) => b.score - a.score)
+    scores.forEach((s, i) => {
+      s.rank = i === 0 || scores[i - 1].score !== s.score ? i + 1 : scores[i - 1].rank
+    })
+    return scores
+  },
+}
+
+const zeroOneStrategy: GameModeStrategy = {
+  maxRounds: 20,
+
+  calculateRoundScore(throws: DartThrow[]): number {
+    return throws.reduce((sum, t) => sum + getThrowScore(t), 0)
+  },
+
+  getTotalScore(player: PlayerState): number {
+    return player.rounds.reduce(
+      (sum, round) => sum + round.reduce((s, t) => s + getThrowScore(t), 0),
+      0
+    )
+  },
+
+  isGameOver(state: GameState): boolean {
+    const startScore = state.startScore ?? 501
+    for (const player of state.players) {
+      const used = this.getTotalScore(player)
+      if (startScore - used === 0) return true
+    }
+    return state.currentRound >= this.maxRounds && state.currentPlayerIndex === 0 && state.currentThrows.length === 0
+  },
+
+  getRankings(players: PlayerState[]): { playerIndex: number; rank: number; score: number }[] {
+    const scores = players.map((p, i) => ({
+      playerIndex: i,
+      score: this.getTotalScore(p),
+      rank: 0,
+    }))
+    scores.sort((a, b) => b.score - a.score)
+    scores.forEach((s, i) => {
+      s.rank = i === 0 || scores[i - 1].score !== s.score ? i + 1 : scores[i - 1].rank
+    })
+    return scores
+  },
+
+  validateThrow(state: GameState, dart: DartThrow, currentThrows: DartThrow[]): 'valid' | 'bust' {
+    const startScore = state.startScore ?? 501
+    const player = state.players[state.currentPlayerIndex]
+    const usedSoFar = player.rounds.reduce(
+      (sum, round) => sum + round.reduce((s, t) => s + getThrowScore(t), 0),
+      0
+    )
+    const thisRoundSoFar = currentThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
+    const remaining = startScore - usedSoFar - thisRoundSoFar - getThrowScore(dart)
+    if (remaining < 0) return 'bust'
+    return 'valid'
+  },
+}
+
+const cricketStrategy: GameModeStrategy = {
+  maxRounds: 15,
+
+  calculateRoundScore(throws: DartThrow[]): number {
+    return throws.reduce((sum, t) => {
+      if (t === 'miss') return sum
+      if (!CRICKET_NUMBERS.includes(t.number)) return sum
+      const marks = t.multiplier === 'single' ? 1 : t.multiplier === 'double' ? 2 : 3
+      return sum + marks
+    }, 0)
+  },
+
+  getTotalScore(_player: PlayerState): number {
+    // GameView側でstate.cricketScoresを直接参照する
+    return 0
+  },
+
+  isGameOver(state: GameState): boolean {
+    if (!state.cricketMarks || !state.cricketScores) return false
+    const marks = state.cricketMarks
+    const scores = state.cricketScores
+    const playerCount = state.players.length
+
+    // 誰かが全ナンバークローズかチェック
+    for (let pi = 0; pi < playerCount; pi++) {
+      const playerMarks = marks[pi] ?? {}
+      const allClosed = CRICKET_NUMBERS.every(n => (playerMarks[n] ?? 0) >= 3)
+      if (allClosed) {
+        const myScore = scores[pi] ?? 0
+        if (playerCount === 2) {
+          // タイマン: 全クローズ + 最高スコア（相手以上）で勝ち
+          const allOthersLowerOrEqual = state.players.every((_, oi) =>
+            oi === pi || (scores[oi] ?? 0) <= myScore
+          )
+          if (allOthersLowerOrEqual) return true
+        } else {
+          // カットスロート: 全クローズ + 最低スコア（相手以下）で勝ち
+          const allOthersHigherOrEqual = state.players.every((_, oi) =>
+            oi === pi || (scores[oi] ?? 0) >= myScore
+          )
+          if (allOthersHigherOrEqual) return true
+        }
+      }
+    }
+
+    return state.currentRound >= this.maxRounds &&
+      state.currentPlayerIndex === 0 &&
+      state.currentThrows.length === 0
+  },
+
+  getRankings(players: PlayerState[]): { playerIndex: number; rank: number; score: number }[] {
+    // GameView/ResultViewでstate.cricketScoresを直接使う
+    return players.map((_, i) => ({ playerIndex: i, rank: i + 1, score: 0 }))
+  },
+}
+
+const cricketSecretStrategy: GameModeStrategy = {
+  maxRounds: 15,
+
+  calculateRoundScore(throws: DartThrow[]): number {
+    return throws.reduce((sum, t) => {
+      if (t === 'miss') return sum
+      if (!CRICKET_NUMBERS.includes(t.number)) return sum
+      const marks = t.multiplier === 'single' ? 1 : t.multiplier === 'double' ? 2 : 3
+      return sum + marks
+    }, 0)
+  },
+
+  getTotalScore(_player: PlayerState): number {
+    // GameView側でstate.cricketScoresを直接参照する
+    return 0
+  },
+
+  isGameOver(state: GameState): boolean {
+    if (!state.cricketMarks || !state.cricketScores) return false
+    const marks = state.cricketMarks
+    const scores = state.cricketScores
+    const secretNumbers = state.secretNumbers ?? []
+    const playerCount = state.players.length
+
+    // 誰かが全ナンバークローズかチェック
+    for (let pi = 0; pi < playerCount; pi++) {
+      const playerMarks = marks[pi] ?? {}
+      const allClosed = secretNumbers.every(n => (playerMarks[n] ?? 0) >= 3)
+      if (allClosed) {
+        const myScore = scores[pi] ?? 0
+        if (playerCount === 2) {
+          // タイマン: 全クローズ + 最高スコア（相手以上）で勝ち
+          const allOthersLowerOrEqual = state.players.every((_, oi) =>
+            oi === pi || (scores[oi] ?? 0) <= myScore
+          )
+          if (allOthersLowerOrEqual) return true
+        } else {
+          // カットスロート: 全クローズ + 最低スコア（相手以下）で勝ち
+          const allOthersHigherOrEqual = state.players.every((_, oi) =>
+            oi === pi || (scores[oi] ?? 0) >= myScore
+          )
+          if (allOthersHigherOrEqual) return true
+        }
+      }
+    }
+
+    return state.currentRound >= this.maxRounds &&
+      state.currentPlayerIndex === 0 &&
+      state.currentThrows.length === 0
+  },
+
+  getRankings(players: PlayerState[]): { playerIndex: number; rank: number; score: number }[] {
+    // GameView/ResultViewでstate.cricketScoresを直接使う
+    return players.map((_, i) => ({ playerIndex: i, rank: i + 1, score: 0 }))
+  },
+}
+
+export const gameModeStrategies: Record<string, GameModeStrategy> = {
+  'count-up': countUpStrategy,
+  'zero-one': zeroOneStrategy,
+  'cricket': cricketStrategy,
+  'cricket-secret': cricketSecretStrategy,
+}

--- a/src/data/gameModes.ts
+++ b/src/data/gameModes.ts
@@ -162,6 +162,7 @@ const cricketSecretStrategy: GameModeStrategy = {
     const marks = state.cricketMarks
     const scores = state.cricketScores
     const secretNumbers = state.secretNumbers ?? []
+    if (secretNumbers.length !== 7) return false
     const playerCount = state.players.length
 
     // 誰かが全ナンバークローズかチェック

--- a/src/hooks/useJunoGame.ts
+++ b/src/hooks/useJunoGame.ts
@@ -1,0 +1,526 @@
+import { useReducer, useEffect } from 'react'
+import type { GameState, GameAction, Segment } from '../types/juno.types'
+import { getThrowScore, isCricketMode } from '../types/juno.types'
+import { gameModeStrategies, CRICKET_NUMBERS } from '../data/gameModes'
+
+const STORAGE_KEY = 'juno-game'
+
+function applySecretDiscoveryBonus(
+  cricketMarks: NonNullable<GameState['cricketMarks']>,
+  cricketScores: number[],
+  playerIndex: number,
+  dart: Segment,
+  playerCount: number,
+): { marks: NonNullable<GameState['cricketMarks']>; scores: number[] } {
+  const marks = JSON.parse(JSON.stringify(cricketMarks))
+  const scores = [...cricketScores]
+  if (!marks[playerIndex]) marks[playerIndex] = {}
+
+  let bonusMarks = 0
+  if (dart.multiplier === 'single') {
+    bonusMarks = 2
+  } else if (dart.multiplier === 'double') {
+    bonusMarks = 3
+  } else {
+    bonusMarks = 3
+    // トリプル: 1オーバーマーク → プレイヤー人数で分岐
+    if (playerCount === 2) {
+      // タイマン: 自分に加点
+      scores[playerIndex] = (scores[playerIndex] ?? 0) + dart.number * 1
+    } else {
+      // カットスロート: 他プレイヤーに加点
+      for (let oi = 0; oi < playerCount; oi++) {
+        if (oi === playerIndex) continue
+        const otherMarks = marks[oi]?.[dart.number] ?? 0
+        if (otherMarks < 3) {
+          scores[oi] = (scores[oi] ?? 0) + dart.number * 1
+        }
+      }
+    }
+  }
+
+  marks[playerIndex][dart.number] = (marks[playerIndex][dart.number] ?? 0) + bonusMarks
+  return { marks, scores }
+}
+
+const initialState: GameState = {
+  mode: 'count-up',
+  players: [],
+  currentPlayerIndex: 0,
+  currentRound: 0,
+  maxRounds: 8,
+  phase: 'setup',
+  currentThrows: [],
+  waitingConfirm: false,
+  startScore: undefined,
+  cricketMarks: undefined,
+  cricketScores: undefined,
+}
+
+function loadState(): GameState {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      // 最低限のバリデーション
+      if (parsed && typeof parsed === 'object' && parsed.phase === 'playing' && Array.isArray(parsed.players) && typeof parsed.currentPlayerIndex === 'number') {
+        return parsed as GameState
+      }
+    }
+  } catch {}
+  return initialState
+}
+
+function applyCricketThrows(
+  state: GameState,
+  playerIndex: number,
+  throws: GameState['currentThrows'],
+  targetNumbers?: number[]
+): { marks: GameState['cricketMarks']; scores: GameState['cricketScores'] } {
+  const marks = JSON.parse(JSON.stringify(state.cricketMarks ?? {})) as NonNullable<GameState['cricketMarks']>
+  const scores = [...(state.cricketScores ?? state.players.map(() => 0))]
+  const playerCount = state.players.length
+  const numbersToCheck = targetNumbers ?? CRICKET_NUMBERS
+
+  if (!marks[playerIndex]) marks[playerIndex] = {}
+
+  for (const t of throws) {
+    if (t === 'miss') continue
+    if (!numbersToCheck.includes(t.number)) continue
+
+    const dartMarks = t.multiplier === 'single' ? 1 : t.multiplier === 'double' ? 2 : 3
+    const prevMarks = marks[playerIndex][t.number] ?? 0
+    const newTotal = prevMarks + dartMarks
+
+    marks[playerIndex][t.number] = newTotal
+
+    // クローズ後のオーバーマーク → プレイヤー人数で分岐
+    if (newTotal > 3) {
+      const overMarks = newTotal - Math.max(prevMarks, 3)
+      if (overMarks > 0) {
+        if (playerCount === 2) {
+          // タイマン: 自分に加点
+          scores[playerIndex] = (scores[playerIndex] ?? 0) + t.number * overMarks
+        } else {
+          // カットスロート: 他プレイヤーに加点
+          for (let oi = 0; oi < playerCount; oi++) {
+            if (oi === playerIndex) continue
+            const otherMarks = marks[oi]?.[t.number] ?? 0
+            if (otherMarks < 3) {
+              scores[oi] = (scores[oi] ?? 0) + t.number * overMarks
+            }
+          }
+        }
+      }
+    } else if (prevMarks < 3 && newTotal >= 3) {
+      // 今回クローズした → クローズした時点でのオーバー分を計算 → プレイヤー人数で分岐
+      const overAfterClose = newTotal - 3
+      if (overAfterClose > 0) {
+        if (playerCount === 2) {
+          // タイマン: 自分に加点
+          scores[playerIndex] = (scores[playerIndex] ?? 0) + t.number * overAfterClose
+        } else {
+          // カットスロート: 他プレイヤーに加点
+          for (let oi = 0; oi < playerCount; oi++) {
+            if (oi === playerIndex) continue
+            const otherMarks = marks[oi]?.[t.number] ?? 0
+            if (otherMarks < 3) {
+              scores[oi] = (scores[oi] ?? 0) + t.number * overAfterClose
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { marks, scores }
+}
+
+function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case 'START_GAME': {
+      const strategy = gameModeStrategies[action.mode]
+      const isInitializingCricketMode = isCricketMode(action.mode)
+
+      let secretNumbers: number[] | undefined = undefined
+      if (action.mode === 'cricket-secret') {
+        // 1-20とBULL(25)の21個からランダムに7つ選出
+        const allNumbers = Array.from({ length: 21 }, (_, i) => i < 20 ? i + 1 : 25)
+        for (let i = allNumbers.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [allNumbers[i], allNumbers[j]] = [allNumbers[j], allNumbers[i]]
+        }
+        secretNumbers = allNumbers.slice(0, 7)
+      }
+
+      return {
+        ...initialState,
+        mode: action.mode,
+        maxRounds: action.mode === 'zero-one'
+          ? (action.startScore === 301 ? 10 : 15)
+          : strategy.maxRounds,
+        players: action.players.map((name) => ({ name, rounds: [] })),
+        phase: 'playing',
+        currentPlayerIndex: 0,
+        currentRound: 0,
+        currentThrows: [],
+        waitingConfirm: false,
+        startScore: action.startScore,
+        cricketMarks: isInitializingCricketMode
+          ? Object.fromEntries(action.players.map((_, i) => [i, {}]))
+          : undefined,
+        cricketScores: isInitializingCricketMode
+          ? new Array(action.players.length).fill(0)
+          : undefined,
+        secretNumbers,
+        revealedNumbers: action.mode === 'cricket-secret' ? [] : undefined,
+      }
+    }
+
+    case 'RECORD_THROW': {
+      // バスト判定
+      const strategyForThrow = gameModeStrategies[state.mode]
+      if (strategyForThrow.validateThrow) {
+        const result = strategyForThrow.validateThrow(state, action.dart, state.currentThrows)
+        if (result === 'bust') {
+          const newPlayers = state.players.map((p, i) => {
+            if (i !== state.currentPlayerIndex) return p
+            return { ...p, rounds: [...p.rounds, []] }
+          })
+          const isLastPlayer = state.currentPlayerIndex === state.players.length - 1
+          return {
+            ...state,
+            players: newPlayers,
+            currentPlayerIndex: isLastPlayer ? 0 : state.currentPlayerIndex + 1,
+            currentRound: isLastPlayer ? state.currentRound + 1 : state.currentRound,
+            currentThrows: [],
+          }
+        }
+      }
+
+      const newThrows = [...state.currentThrows, action.dart]
+
+      // 01: ちょうど0になったら即座にラウンド確定
+      if (strategyForThrow.validateThrow && state.startScore !== undefined) {
+        const player = state.players[state.currentPlayerIndex]
+        const usedSoFar = player.rounds.reduce(
+          (sum, round) => sum + round.reduce((s, t) => s + getThrowScore(t), 0),
+          0
+        )
+        const thisRoundTotal = newThrows.reduce((sum, t) => sum + getThrowScore(t), 0)
+        if (state.startScore - usedSoFar - thisRoundTotal === 0) {
+          const newPlayers = state.players.map((p, i) => {
+            if (i !== state.currentPlayerIndex) return p
+            return { ...p, rounds: [...p.rounds, newThrows] }
+          })
+          const nextState: GameState = { ...state, players: newPlayers, currentThrows: [] }
+          if (strategyForThrow.isGameOver(nextState)) {
+            return { ...nextState, phase: 'result' }
+          }
+          return nextState
+        }
+      }
+
+      if (newThrows.length < 3) {
+        if (state.mode === 'cricket') {
+          const { marks, scores } = applyCricketThrows(state, state.currentPlayerIndex, [action.dart])
+          return { ...state, currentThrows: newThrows, cricketMarks: marks, cricketScores: scores }
+        }
+
+        if (state.mode === 'cricket-secret') {
+          const secretNumbers = state.secretNumbers ?? []
+          let newRevealedNumbers = [...(state.revealedNumbers ?? [])]
+          let nextState: GameState = { ...state, currentThrows: newThrows }
+
+          // 投げたナンバーがsecretNumbersに含まれるかチェック
+          if (action.dart !== 'miss' && secretNumbers.includes(action.dart.number)) {
+            if (!newRevealedNumbers.includes(action.dart.number)) {
+              // 最初の発見者ボーナス
+              const result = applySecretDiscoveryBonus(
+                state.cricketMarks ?? Object.fromEntries(state.players.map((_, i) => [i, {}])),
+                state.cricketScores ?? state.players.map(() => 0),
+                state.currentPlayerIndex,
+                action.dart,
+                state.players.length,
+              )
+              newRevealedNumbers.push(action.dart.number)
+              nextState = {
+                ...nextState,
+                cricketMarks: result.marks,
+                cricketScores: result.scores,
+                revealedNumbers: newRevealedNumbers,
+              }
+            } else {
+              // 既にrevealedの場合 → 通常cricket処理
+              const { marks, scores } = applyCricketThrows(state, state.currentPlayerIndex, [action.dart], secretNumbers)
+              nextState = { ...nextState, cricketMarks: marks, cricketScores: scores }
+            }
+          }
+
+          return nextState
+        }
+
+        return { ...state, currentThrows: newThrows }
+      }
+
+      const newPlayers = state.players.map((p, i) => {
+        if (i !== state.currentPlayerIndex) return p
+        return { ...p, rounds: [...p.rounds, newThrows] }
+      })
+
+      let nextState: GameState = {
+        ...state,
+        players: newPlayers,
+        currentThrows: newThrows,
+        waitingConfirm: true,
+      }
+
+      // Cricket: マーク・スコア更新
+      if (state.mode === 'cricket') {
+        const { marks, scores } = applyCricketThrows(state, state.currentPlayerIndex, [action.dart])
+        nextState = {
+          ...nextState,
+          cricketMarks: marks,
+          cricketScores: scores,
+        }
+      }
+
+      // Cricket Secret: マーク・スコア更新（3投目の確定時）
+      if (state.mode === 'cricket-secret') {
+        const secretNumbers = state.secretNumbers ?? []
+        let revealedNumbers = [...(state.revealedNumbers ?? [])]
+
+        // 3投目のチェック
+        if (action.dart !== 'miss' && secretNumbers.includes(action.dart.number)) {
+          if (!revealedNumbers.includes(action.dart.number)) {
+            // 最初の発見者ボーナス
+            const result = applySecretDiscoveryBonus(
+              state.cricketMarks ?? Object.fromEntries(state.players.map((_, i) => [i, {}])),
+              state.cricketScores ?? state.players.map(() => 0),
+              state.currentPlayerIndex,
+              action.dart,
+              state.players.length,
+            )
+            revealedNumbers.push(action.dart.number)
+            nextState = {
+              ...nextState,
+              cricketMarks: result.marks,
+              cricketScores: result.scores,
+              revealedNumbers,
+            }
+          } else {
+            // 既にrevealedの場合 → 通常cricket処理
+            const { marks, scores } = applyCricketThrows(state, state.currentPlayerIndex, [action.dart], secretNumbers)
+            nextState = {
+              ...nextState,
+              cricketMarks: marks,
+              cricketScores: scores,
+            }
+          }
+        }
+      }
+
+      // ゲーム終了判定（01のフィニッシュ、Cricketの全クローズ）
+      const strategy = gameModeStrategies[state.mode]
+      if (strategy.isGameOver(nextState)) {
+        return { ...nextState, phase: 'result', waitingConfirm: false }
+      }
+
+      return nextState
+    }
+
+    case 'CONFIRM_TURN': {
+      if (!state.waitingConfirm) return state
+
+      const isLastPlayer = state.currentPlayerIndex === state.players.length - 1
+      const nextPlayerIndex = isLastPlayer ? 0 : state.currentPlayerIndex + 1
+      const nextRound = isLastPlayer ? state.currentRound + 1 : state.currentRound
+
+      return {
+        ...state,
+        currentPlayerIndex: nextPlayerIndex,
+        currentRound: nextRound,
+        currentThrows: [],
+        waitingConfirm: false,
+      }
+    }
+
+    case 'UNDO_THROW': {
+      // Cricket/Cricket-Secret の再計算用ローカル関数
+      function rebuildCricketState(
+        baseState: GameState,
+        players: typeof state.players,
+        currentThrowsToInclude: typeof state.currentThrows,
+        currentPlayerIndexForThrows: number
+      ): Partial<GameState> {
+        const isRebuildingCricketMode = isCricketMode(baseState.mode)
+        if (!isRebuildingCricketMode) return {}
+
+        const playerCount = players.length
+        const secretNumbers = baseState.mode === 'cricket-secret' ? (baseState.secretNumbers ?? []) : undefined
+        const maxRoundCount = players.length > 0 ? Math.max(0, ...players.map(p => p.rounds.length)) : 0
+
+        let rebuildState: GameState = {
+          ...baseState,
+          players,
+          cricketMarks: Object.fromEntries(Array.from({ length: playerCount }, (_, i) => [i, {}])),
+          cricketScores: new Array(playerCount).fill(0),
+        }
+
+        // cricket-secret の場合、revealed ナンバーを追跡
+        let revealed = new Set<number>()
+
+        // 確定済みラウンドを再計算（秒序順）
+        for (let r = 0; r < maxRoundCount; r++) {
+          for (let pi = 0; pi < playerCount; pi++) {
+            const round = players[pi].rounds[r]
+            if (!round) continue
+
+            if (baseState.mode === 'cricket-secret') {
+              // cricket-secret: 各投球ごとに初発見ボーナスを処理
+              const secretNums = secretNumbers ?? []
+              for (const dart of round) {
+                if (dart === 'miss') continue
+                if (!secretNums.includes(dart.number)) continue
+
+                if (!revealed.has(dart.number)) {
+                  // 初発見ボーナス
+                  revealed.add(dart.number)
+                  const result = applySecretDiscoveryBonus(
+                    rebuildState.cricketMarks ?? Object.fromEntries(Array.from({ length: playerCount }, (_, i) => [i, {}])),
+                    rebuildState.cricketScores ?? new Array(playerCount).fill(0),
+                    pi,
+                    dart,
+                    playerCount,
+                  )
+                  rebuildState = { ...rebuildState, cricketMarks: result.marks, cricketScores: result.scores }
+                } else {
+                  // 既に revealed → 通常処理
+                  const { marks, scores } = applyCricketThrows(rebuildState, pi, [dart], secretNums)
+                  rebuildState = { ...rebuildState, cricketMarks: marks, cricketScores: scores }
+                }
+              }
+            } else {
+              // 通常cricket: 1ラウンド分を一括処理
+              const { marks, scores } = applyCricketThrows(rebuildState, pi, round)
+              rebuildState = { ...rebuildState, cricketMarks: marks, cricketScores: scores }
+            }
+          }
+        }
+
+        // currentThrows も反映（まだ rounds に入ってない投球分）
+        if (currentThrowsToInclude.length > 0) {
+          if (baseState.mode === 'cricket-secret') {
+            const secretNums = secretNumbers ?? []
+            for (const dart of currentThrowsToInclude) {
+              if (dart === 'miss') continue
+              if (!secretNums.includes(dart.number)) continue
+
+              if (!revealed.has(dart.number)) {
+                revealed.add(dart.number)
+                const result = applySecretDiscoveryBonus(
+                  rebuildState.cricketMarks ?? Object.fromEntries(Array.from({ length: playerCount }, (_, i) => [i, {}])),
+                  rebuildState.cricketScores ?? new Array(playerCount).fill(0),
+                  currentPlayerIndexForThrows,
+                  dart,
+                  playerCount,
+                )
+                rebuildState = { ...rebuildState, cricketMarks: result.marks, cricketScores: result.scores }
+              } else {
+                const { marks, scores } = applyCricketThrows(rebuildState, currentPlayerIndexForThrows, [dart], secretNums)
+                rebuildState = { ...rebuildState, cricketMarks: marks, cricketScores: scores }
+              }
+            }
+          } else {
+            // 通常cricket
+            const { marks, scores } = applyCricketThrows(rebuildState, currentPlayerIndexForThrows, currentThrowsToInclude)
+            rebuildState = { ...rebuildState, cricketMarks: marks, cricketScores: scores }
+          }
+        }
+
+        const result: Partial<GameState> = {
+          cricketMarks: rebuildState.cricketMarks,
+          cricketScores: rebuildState.cricketScores,
+        }
+
+        if (baseState.mode === 'cricket-secret') {
+          result.revealedNumbers = Array.from(revealed)
+        }
+
+        return result
+      }
+
+      // パターン1: waitingConfirm 中のUNDO
+      if (state.waitingConfirm) {
+        const restoredThrows = state.currentThrows.slice(0, -1)
+        const newPlayers = state.players.map((p, i) => {
+          if (i !== state.currentPlayerIndex) return p
+          return { ...p, rounds: p.rounds.slice(0, -1) }
+        })
+        const cricketRebuild = rebuildCricketState(state, newPlayers, restoredThrows, state.currentPlayerIndex)
+        return { ...state, players: newPlayers, currentThrows: restoredThrows, waitingConfirm: false, ...cricketRebuild }
+      }
+
+      // パターン2: currentThrows.length > 0 のUNDO
+      if (state.currentThrows.length > 0) {
+        const restoredThrows = state.currentThrows.slice(0, -1)
+        const cricketRebuild = rebuildCricketState(state, state.players, restoredThrows, state.currentPlayerIndex)
+        return { ...state, currentThrows: restoredThrows, ...cricketRebuild }
+      }
+
+      // パターン3: 前プレイヤーに戻るUNDO
+      const prevPlayerIndex = state.currentPlayerIndex === 0
+        ? state.players.length - 1
+        : state.currentPlayerIndex - 1
+      const prevRound = state.currentPlayerIndex === 0
+        ? state.currentRound - 1
+        : state.currentRound
+
+      if (prevRound < 0) return state
+
+      const prevPlayer = state.players[prevPlayerIndex]
+      if (prevPlayer.rounds.length === 0) return state
+
+      const lastRound = prevPlayer.rounds[prevPlayer.rounds.length - 1]
+      const restoredThrows = lastRound.slice(0, -1)
+
+      const newPlayers = state.players.map((p, i) => {
+        if (i !== prevPlayerIndex) return p
+        return { ...p, rounds: p.rounds.slice(0, -1) }
+      })
+
+      const cricketRebuild = rebuildCricketState(state, newPlayers, restoredThrows, prevPlayerIndex)
+      return {
+        ...state,
+        players: newPlayers,
+        currentPlayerIndex: prevPlayerIndex,
+        currentRound: prevRound,
+        currentThrows: restoredThrows,
+        ...cricketRebuild,
+      }
+    }
+
+    case 'RESET_GAME': {
+      return { ...initialState, waitingConfirm: false }
+    }
+
+    default:
+      return state
+  }
+}
+
+export function useJunoGame() {
+  const [state, dispatch] = useReducer(gameReducer, undefined, loadState)
+
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    } else {
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  }, [state])
+
+  const strategy = gameModeStrategies[state.mode]
+
+  return { state, dispatch, strategy }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -315,6 +315,18 @@ export function Home() {
                   </p>
                 </Link>
                 
+                <Link
+                  to="/juno"
+                  className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
+                >
+                  <h3 className="font-semibold text-gray-900 mb-1 group-hover:text-jupiter-600">
+                    Juno - Darts Scorer
+                  </h3>
+                  <p className="text-sm text-gray-600">
+                    ダーツスコア計算ツール
+                  </p>
+                </Link>
+
                 <div className="block p-4 bg-gray-50 rounded-lg opacity-50">
                   <h3 className="font-semibold text-gray-500 mb-1">
                     その他のプロジェクト

--- a/src/pages/Juno.tsx
+++ b/src/pages/Juno.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { useJunoGame } from '../hooks/useJunoGame'
+import { PlayerSetup } from '../components/Juno/PlayerSetup'
+import { GameView } from '../components/Juno/GameView'
+import { ResultView } from '../components/Juno/ResultView'
+
+export default function Juno() {
+  const { state, dispatch, strategy } = useJunoGame()
+
+  useEffect(() => {
+    document.title = 'Juno - Darts Scorer'
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = originalOverflow
+    }
+  }, [])
+
+  return (
+    <div className="h-[100dvh] bg-[#0a0a0a] overflow-hidden">
+      <div className={`h-full max-w-4xl mx-auto px-4 overflow-hidden ${state.phase === 'playing' ? 'py-2' : 'py-6'}`}>
+        {state.phase === 'setup' && <PlayerSetup dispatch={dispatch} />}
+        {state.phase === 'playing' && (
+          <GameView state={state} strategy={strategy} dispatch={dispatch} />
+        )}
+        {state.phase === 'result' && (
+          <ResultView state={state} strategy={strategy} dispatch={dispatch} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/types/juno.types.ts
+++ b/src/types/juno.types.ts
@@ -1,0 +1,69 @@
+export type DartNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 25
+
+export type Multiplier = 'single' | 'double' | 'triple'
+
+export interface Segment {
+  number: DartNumber
+  multiplier: Multiplier
+}
+
+export type DartThrow = Segment | 'miss'
+
+export function getThrowScore(t: DartThrow): number {
+  if (t === 'miss') return 0
+  const mult = t.multiplier === 'single' ? 1 : t.multiplier === 'double' ? 2 : 3
+  return t.number * mult
+}
+
+export function formatThrow(t: DartThrow): string {
+  if (t === 'miss') return 'MISS'
+  if (t.number === 25) {
+    return t.multiplier === 'double' ? 'BULL' : 'OUT BULL'
+  }
+  const prefix = t.multiplier === 'single' ? '' : t.multiplier === 'double' ? 'D' : 'T'
+  return `${prefix}${t.number}`
+}
+
+export interface PlayerState {
+  name: string
+  rounds: DartThrow[][]
+}
+
+export type GamePhase = 'setup' | 'playing' | 'result'
+export type GameMode = 'count-up' | 'zero-one' | 'cricket' | 'cricket-secret'
+
+export function isCricketMode(mode: GameMode): boolean {
+  return mode === 'cricket' || mode === 'cricket-secret'
+}
+
+export interface GameState {
+  mode: GameMode
+  players: PlayerState[]
+  currentPlayerIndex: number
+  currentRound: number
+  maxRounds: number
+  phase: GamePhase
+  currentThrows: DartThrow[]
+  waitingConfirm: boolean
+  startScore?: number
+  cricketMarks?: { [playerIndex: number]: { [number: number]: number } }
+  cricketScores?: number[]
+  secretNumbers?: number[]
+  revealedNumbers?: number[]
+}
+
+export type GameAction =
+  | { type: 'START_GAME'; players: string[]; mode: GameMode; startScore?: number }
+  | { type: 'RECORD_THROW'; dart: DartThrow }
+  | { type: 'CONFIRM_TURN' }
+  | { type: 'UNDO_THROW' }
+  | { type: 'RESET_GAME' }
+
+export interface GameModeStrategy {
+  maxRounds: number
+  calculateRoundScore(throws: DartThrow[]): number
+  getTotalScore(player: PlayerState): number
+  isGameOver(state: GameState): boolean
+  getRankings(players: PlayerState[]): { playerIndex: number; rank: number; score: number }[]
+  validateThrow?(state: GameState, dart: DartThrow, currentThrows: DartThrow[]): 'valid' | 'bust'
+}


### PR DESCRIPTION
## Summary
- ブラウザ完結のダーツスコアリングツール「Juno」を `/juno` ルートに追加
- Count Up / 01 (301/501/701) / Cricket / Secret Cricket の4モード対応
- SVGダーツボード（タップ入力、MISSリング、チェックアウトハイライト、Cricket盤面ハイライト）
- スマホ最適化（100dvh上下分割レイアウト、NEXT PLAYERオーバーレイ）

## Test plan
- [ ] 各モードでゲーム開始〜終了まで通しプレイ
- [ ] UNDO動作確認（投球中、確認フェーズ中、前プレイヤーへの巻き戻し）
- [ ] Cricket: 2人時の自分加点 / 3人以上のカットスロート
- [ ] Secret Cricket: ランダムナンバー選出、初発見ボーナス、紫オーバーレイ
- [ ] localStorage永続化（ゲーム復帰、プレイヤー名履歴、設定記憶）
- [ ] スマホ実機での操作性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Juno darts scorer: full playable page (setup, live game, results) with multi-mode play (Count Up, 01 with checkout hints, Cricket, Secret Cricket), 1–4 players, shuffle, name history/suggestions, and persistent settings.
  * Interactive UI: SVG dartboard, segment selector, throw history, multiple scoreboards, round indicator, and result/rematch/reset flow.

* **Chores**
  * Added lucide-react dependency.
  * App locale set to Japanese.
  * Minor config and ignore-file updates; Firebase init now guards missing API key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->