### PR TITLE
feat: 初回ログイン時オンボーディング + アセットアップロード自動選択

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -30,6 +30,7 @@ export const { auth, signIn, signOut, store } = convexAuth({
         name: profile.name ?? undefined,
         image: profile.image ?? undefined,
         email: profile.email ?? undefined,
+        onboarded: false,
       });
     },
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,6 +4,10 @@ import { authTables } from "@convex-dev/auth/server";
 
 export default defineSchema({
   ...authTables,
+  users: defineTable({
+    ...authTables.users.validator.fields,
+    onboarded: v.optional(v.boolean()),
+  }),
   rooms: defineTable({
     id: v.string(),
     name: v.string(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -23,6 +23,7 @@ export const getMe = query({
       id: userId,
       name: user?.name ?? identity.name ?? null,
       image: user?.image ?? identity.pictureUrl ?? null,
+      onboarded: user?.onboarded ?? true,
     };
   },
 });
@@ -39,8 +40,19 @@ export const updateMe = mutation({
     const patch: Record<string, unknown> = {};
     if (args.name !== undefined) patch.name = args.name;
     if (args.image !== undefined) patch.image = args.image;
+    patch.onboarded = true;
     if (Object.keys(patch).length > 0) {
       await ctx.db.patch(userId as Id<"users">, patch);
     }
+  },
+});
+
+export const completeOnboarding = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    const userId = getUserId(identity);
+    await ctx.db.patch(userId as Id<"users">, { onboarded: true });
   },
 });

--- a/src/components/Adrastea/AssetLibraryModal.tsx
+++ b/src/components/Adrastea/AssetLibraryModal.tsx
@@ -127,10 +127,16 @@ export function AssetLibraryModal({ onClose, onSelect, initialTab = 'image' }: A
     async (file: File) => {
       setUploading(true);
       try {
+        let result: Asset | null = null;
         if (activeTab === 'audio') {
-          await uploadAudioAsset(file);
+          result = await uploadAudioAsset(file);
         } else {
-          await uploadAsset(file);
+          result = await uploadAsset(file);
+        }
+        if (result && onSelect) {
+          previewAudioRef.current?.pause();
+          onSelect(result.url, result.id, result.title || result.filename, result.width, result.height);
+          onClose();
         }
       } catch (err) {
         console.error('アップロード失敗:', err);
@@ -139,7 +145,7 @@ export function AssetLibraryModal({ onClose, onSelect, initialTab = 'image' }: A
         setAddMode(null);
       }
     },
-    [activeTab, uploadAsset, uploadAudioAsset]
+    [activeTab, uploadAsset, uploadAudioAsset, onSelect, onClose]
   );
 
   const dnd = useDragDropOverlay(handleUpload);

--- a/src/components/Adrastea/OnboardingModal.tsx
+++ b/src/components/Adrastea/OnboardingModal.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { theme } from '../../styles/theme';
+import { AdInput, AdButton } from './ui';
+import { AssetPicker } from './AssetPicker';
+
+interface OnboardingModalProps {
+  defaultName: string;
+  defaultImage: string | null;
+  isGuest: boolean;
+  onComplete: (data: { display_name: string; avatar_url: string | null }) => Promise<void>;
+  onSkip: () => Promise<void>;
+}
+
+export function OnboardingModal({ defaultName, defaultImage, isGuest, onComplete, onSkip }: OnboardingModalProps) {
+  const [name, setName] = useState(defaultName);
+  const [image, setImage] = useState<string | null>(defaultImage);
+  const [saving, setSaving] = useState(false);
+
+  const handleComplete = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      await onComplete({ display_name: name.trim(), avatar_url: image });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSkip = async () => {
+    setSaving(true);
+    try {
+      await onSkip();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: theme.bgBase, zIndex: 9999,
+    }}>
+      <div style={{
+        background: theme.bgSurface, border: `1px solid ${theme.border}`,
+        padding: '40px', width: '400px', color: theme.textPrimary,
+      }}>
+        <h2 style={{ margin: '0 0 8px', fontSize: '1.3rem', textAlign: 'center' }}>
+          プロフィール設定
+        </h2>
+        <p style={{ margin: '0 0 24px', color: theme.textSecondary, fontSize: '0.85rem', textAlign: 'center' }}>
+          表示名とアバターを設定してください
+        </p>
+
+        {/* アバター */}
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '20px' }}>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{
+              width: 80, height: 80, borderRadius: '50%', overflow: 'hidden',
+              border: `2px solid ${theme.border}`, margin: '0 auto 8px',
+              background: theme.bgDeep,
+            }}>
+              {image ? (
+                <img src={image} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+              ) : (
+                <div style={{
+                  width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: '2rem', color: theme.textMuted,
+                }}>
+                  {name?.[0]?.toUpperCase() ?? '?'}
+                </div>
+              )}
+            </div>
+            {!isGuest && (
+              <AssetPicker
+                currentUrl={image}
+                onSelect={(url) => setImage(url)}
+                label="アバターを変更"
+              />
+            )}
+            {isGuest && (
+              <AdInput
+                value={image ?? ''}
+                onChange={(e) => setImage(e.target.value || null)}
+                placeholder="画像URL（省略可）"
+                style={{ fontSize: '0.8rem', marginTop: '4px' }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* 表示名 */}
+        <div style={{ marginBottom: '24px' }}>
+          <label style={{ display: 'block', marginBottom: '6px', fontSize: '0.85rem', color: theme.textSecondary }}>
+            表示名
+          </label>
+          <AdInput
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="表示名を入力"
+            style={{ width: '100%' }}
+            maxLength={30}
+          />
+        </div>
+
+        {/* ボタン */}
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <AdButton
+            onClick={handleSkip}
+            disabled={saving}
+            style={{ flex: 1, background: 'transparent', border: `1px solid ${theme.border}`, color: theme.textSecondary }}
+          >
+            スキップ
+          </AdButton>
+          <AdButton
+            onClick={handleComplete}
+            disabled={saving || !name.trim()}
+            style={{ flex: 1, background: theme.accent, color: theme.textOnAccent }}
+          >
+            {saving ? '保存中...' : '保存'}
+          </AdButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ interface AuthContextValue {
   profile: UserProfile | null;
   isGuest: boolean;
   loading: boolean;
+  onboarded: boolean;
   signIn: () => Promise<void>;
   signInAsGuest: (displayName: string) => Promise<void>;
   signOut: () => Promise<void>;
@@ -68,6 +69,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const isGuest = user?.isGuest ?? false;
   // viewerData が undefined = ロード中。null = 未認証
   const loading = isLoading || (isAuthenticated && viewerData === undefined);
+  const onboarded = viewerData?.onboarded ?? true;
 
   return (
     <AuthContext.Provider value={{
@@ -75,6 +77,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       profile,
       isGuest,
       loading,
+      onboarded,
       signIn,
       signInAsGuest,
       signOut,

--- a/src/pages/Adrastea.tsx
+++ b/src/pages/Adrastea.tsx
@@ -7,6 +7,7 @@ import { TopToolbar } from '../components/Adrastea/TopToolbar';
 import { DockLayout } from '../components/Adrastea/DockLayout';
 import { SettingsModal } from '../components/Adrastea/SettingsModal';
 import { CutinOverlay } from '../components/Adrastea/CutinOverlay';
+import { OnboardingModal } from '../components/Adrastea/OnboardingModal';
 import { AdrasteaProvider, useAdrasteaContext } from '../contexts/AdrasteaContext';
 import { useAuth } from '../contexts/AuthContext';
 import { usePermission } from '../hooks/usePermission';
@@ -172,7 +173,7 @@ function AdrasteaRoom() {
 const Adrastea: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
-  const { user, isGuest, loading: authLoading, signIn, signInAsGuest, signOut } = useAuth();
+  const { user, isGuest, loading: authLoading, signIn, signInAsGuest, signOut, onboarded, updateProfile } = useAuth();
 
   // Convex から room データを取得
   const roomData = useQuery(
@@ -203,6 +204,7 @@ const Adrastea: React.FC = () => {
   const [joinDone, setJoinDone] = useState(isGuest || !roomId); // ゲストは join 不要
   const [joinedRole, setJoinedRole] = useState<'owner' | 'sub_owner' | 'user' | 'guest' | null>(null);
   const joinMutation = useMutation(api.room_members.join);
+  const completeOnboardingMutation = useMutation(api.users.completeOnboarding);
 
   // ルーム入室時に join を呼ぶ
   useEffect(() => {
@@ -300,6 +302,23 @@ const Adrastea: React.FC = () => {
           </button>
         </div>
       </div>
+    );
+  }
+
+  // オンボーディング（初回ログイン時）
+  if (!onboarded && !isGuest) {
+    return (
+      <OnboardingModal
+        defaultName={user?.displayName ?? ''}
+        defaultImage={user?.avatarUrl ?? null}
+        isGuest={isGuest}
+        onComplete={async (data) => {
+          await updateProfile(data);
+        }}
+        onSkip={async () => {
+          await completeOnboardingMutation();
+        }}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- 初回ログイン時にプロフィール設定画面（表示名・アバター）を表示するオンボーディング機能を追加
- `users` テーブルに `onboarded` フラグを追加し、未設定ユーザーに `OnboardingModal` を表示（スキップ可）
- `AssetLibraryModal` でアップロード完了後、`onSelect` が渡されている場合は自動的にアップロードしたアセットを選択してモーダルを閉じるように改善（全利用箇所に適用）

## Test plan
- [ ] 新規Googleログイン → オンボーディング画面が表示される
- [ ] 表示名・アバター設定して保存 → プロフィール反映、次回ログインではオンボーディング非表示
- [ ] スキップ → オンボーディング非表示になり通常画面へ
- [ ] 既存ユーザー → オンボーディングが表示されない（`onboarded` 未設定は `true` 扱い）
- [ ] AssetLibraryModal で画像D&Dアップロード → 自動選択されてモーダルが閉じる
- [ ] AssetLibraryModal を単体管理画面で開いた場合（`onSelect` なし）→ 従来通りアップロードのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)