### PR TITLE
feat: R2 Worker CORS ワイルドカード対応

### DIFF
--- a/worker/src/utils/cors.ts
+++ b/worker/src/utils/cors.ts
@@ -8,7 +8,14 @@ export function corsHeaders(origin: string, allowedOrigins: string): Record<stri
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     };
   }
-  if (!origins.includes(origin)) return {};
+  const isAllowed = origins.some((allowed) => {
+    if (allowed.startsWith('https://*.')) {
+      const suffix = allowed.slice('https://*'.length);
+      return origin.startsWith('https://') && origin.endsWith(suffix);
+    }
+    return allowed === origin;
+  });
+  if (!isAllowed) return {};
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,7 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 [vars]
-ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:6100,http://100.121.7.83:5173,http://100.121.7.83:6100,https://jupiter-systems.pages.dev,https://jupiter-systems.vercel.app"
+ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:6100,http://100.121.7.83:5173,http://100.121.7.83:6100,https://jupiter-systems.pages.dev,https://*.vercel.app"
 
 [[r2_buckets]]
 binding = "R2_BUCKET"
@@ -18,7 +18,7 @@ database_id = "3816e6dc-5093-47da-8811-ea36ea6257c2"
 name = "adrastea-r2-proxy-staging"
 
 [env.staging.vars]
-ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:6100,http://100.121.7.83:5173,http://100.121.7.83:6100,https://jupiter-systems-git-feat-adrastea-deploy-6m10cmuks-projects.vercel.app,https://jupiter-systems-git-feat-adrastea-6m10cmuks-projects.vercel.app,https://jupiter-systems-git-feat-adrastea-character-6m10cmuks-projects.vercel.app"
+ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:6100,http://100.121.7.83:5173,http://100.121.7.83:6100,https://*.vercel.app"
 
 [[env.staging.r2_buckets]]
 binding = "R2_BUCKET"


### PR DESCRIPTION
## Summary
- R2 Worker の CORS 設定で `https://*.vercel.app` のようなワイルドカードパターンをサポート
- Vercel プレビュー環境のオリジンがブランチごとに変わる問題を根本解決（個別URL追加不要に）
- `wrangler.toml` の本番・staging 両方で `https://*.vercel.app` に統一

## Test plan
- [ ] Vercel プレビュー環境からアセットAPI（`/api/assets`）にアクセスできる
- [ ] localhost からのアクセスが引き続き動作する
- [ ] 許可されていないオリジンからはCORSブロックされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)