### PR TITLE
feat: iachara クリップボードインポート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@vitejs/plugin-basic-ssl": "^2.2.0",
         "@vitejs/plugin-react": "^4.6.0",
         "ansi-regex": "^6.2.2",
         "autoprefixer": "^10.4.21",
@@ -3959,6 +3960,19 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.2.0.tgz",
+      "integrity": "sha512-nmyQ1HGRkfUxjsv3jw0+hMhEdZdrtkvMTdkzRUaRWfiO6PCWw2V2Pz3gldCq96Tn9S8htcgdTxw/gmbLLEbfYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-basic-ssl": "^2.2.0",
     "@vitejs/plugin-react": "^4.6.0",
     "ansi-regex": "^6.2.2",
     "autoprefixer": "^10.4.21",

--- a/src/components/Adrastea/Board.tsx
+++ b/src/components/Adrastea/Board.tsx
@@ -32,6 +32,7 @@ interface BoardProps {
   onSelectCharacter?: (charId: string) => void;
   onDoubleClickCharacter?: (charId: string) => void;
   onContextMenuCharacter?: (charId: string, e: React.MouseEvent) => void;
+  onPaste?: () => void;
   currentUserId?: string;
   selectedObjectId?: string | null;
   selectedObjectIds?: string[];
@@ -172,11 +173,12 @@ export function getViewportCenter(stage: StageType | null): { x: number; y: numb
   };
 }
 
-export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces, objects = [], activeScene, gridVisible = true, characters, onMovePiece, onRemovePiece, onEditPiece, onMoveObject, onSelectObject, onEditObject, onResizeObject, onSyncObjectSize, onUpdateCharacterBoardPosition, onSelectCharacter, onDoubleClickCharacter, onContextMenuCharacter, currentUserId, selectedObjectId, selectedObjectIds, selectedCharacterId, children }, ref) {
+export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces, objects = [], activeScene, gridVisible = true, characters, onMovePiece, onRemovePiece, onEditPiece, onMoveObject, onSelectObject, onEditObject, onResizeObject, onSyncObjectSize, onUpdateCharacterBoardPosition, onSelectCharacter, onDoubleClickCharacter, onContextMenuCharacter, onPaste, currentUserId, selectedObjectId, selectedObjectIds, selectedCharacterId, children }, ref) {
   const stageRef = useRef<StageType>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
   const [contextMenuState, setContextMenuState] = useState<{ x: number; y: number; pieceId: string } | null>(null);
+  const [bgContextMenuState, setBgContextMenuState] = useState<{ x: number; y: number } | null>(null);
 
   const fitToScreen = useCallback(() => {
     const stage = stageRef.current;
@@ -304,12 +306,13 @@ export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces
   // Stageクリック: メニュー閉じ + 背景オブジェクト選択
   const handleStageClick = useCallback((e: KonvaEventObject<MouseEvent>) => {
     if (contextMenuState) setContextMenuState(null);
+    if (bgContextMenuState) setBgContextMenuState(null);
     // Stage 直接クリック（空白領域）→ 背景オブジェクトを選択
     if (e.target === e.target.getStage() && onSelectObject) {
       const bg = objects.find(o => o.type === 'background');
       if (bg) onSelectObject(bg.id);
     }
-  }, [contextMenuState, objects, onSelectObject]);
+  }, [contextMenuState, bgContextMenuState, objects, onSelectObject]);
 
   const handleStageDblClick = useCallback((e: KonvaEventObject<MouseEvent>) => {
     if (e.target === e.target.getStage() && onEditObject) {
@@ -396,6 +399,12 @@ export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces
         onWheel={handleWheel}
         onClick={handleStageClick}
         onDblClick={handleStageDblClick}
+        onContextMenu={(e: KonvaEventObject<PointerEvent>) => {
+          if (e.target === e.target.getStage() && onPaste) {
+            e.evt.preventDefault();
+            setBgContextMenuState({ x: e.evt.clientX, y: e.evt.clientY });
+          }
+        }}
         onDragStart={() => { stageRef.current?.container()?.style.setProperty('cursor', 'grabbing'); }}
         onDragEnd={() => { stageRef.current?.container()?.style.setProperty('cursor', 'grab'); }}
         style={{ backgroundColor: 'transparent', position: 'relative', zIndex: 1, cursor: 'grab' }}
@@ -469,7 +478,7 @@ export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces
         onContextMenuCharacter={onContextMenuCharacter}
         selectedCharacterId={selectedCharacterId}
       />
-      {/* 右クリックメニュー（DropdownMenu） */}
+      {/* 右クリックメニュー（駒用） */}
       <DropdownMenu
         mode="context"
         open={contextMenuState !== null}
@@ -488,6 +497,22 @@ export const Board = forwardRef<BoardHandle, BoardProps>(function Board({ pieces
             onClick: () => {
               if (contextMenuState) onRemovePiece(contextMenuState.pieceId);
               setContextMenuState(null);
+            },
+          },
+        ]}
+      />
+      {/* 背景右クリックメニュー */}
+      <DropdownMenu
+        mode="context"
+        open={bgContextMenuState !== null}
+        onOpenChange={(open) => { if (!open) setBgContextMenuState(null); }}
+        position={bgContextMenuState ?? { x: 0, y: 0 }}
+        items={[
+          {
+            label: '貼り付け',
+            onClick: () => {
+              onPaste?.();
+              setBgContextMenuState(null);
             },
           },
         ]}

--- a/src/components/Adrastea/CharacterPanel.tsx
+++ b/src/components/Adrastea/CharacterPanel.tsx
@@ -4,7 +4,7 @@ import { arrayMove } from '@dnd-kit/sortable';
 import type { DragEndEvent } from '@dnd-kit/core';
 import { theme } from '../../styles/theme';
 import type { Character } from '../../types/adrastea.types';
-import { SortableListPanel, SortableListItem, Tooltip, ConfirmModal } from './ui';
+import { SortableListPanel, SortableListItem, Tooltip, ConfirmModal, DropdownMenu } from './ui';
 
 interface CharacterPanelProps {
   characters: Character[];
@@ -18,6 +18,7 @@ interface CharacterPanelProps {
   onRemoveCharacters: (ids: string[]) => void;
   onReorderCharacters?: (orderedIds: string[]) => void;
   onToggleBoardVisible: (charId: string) => void;
+  onPaste?: () => void;
 }
 
 export function CharacterPanel({
@@ -32,8 +33,10 @@ export function CharacterPanel({
   onRemoveCharacters,
   onReorderCharacters,
   onToggleBoardVisible,
+  onPaste,
 }: CharacterPanelProps) {
   const [pendingRemove, setPendingRemove] = useState<{ ids: string[]; msg: string } | null>(null);
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
   const filteredCharacters = characters.filter(c => c.owner_id === currentUserId);
   const canDelete = selectedCharIds.length > 0;
 
@@ -59,7 +62,16 @@ export function CharacterPanel({
 
   return (
     <>
-    <SortableListPanel
+    <div
+      onContextMenu={(e) => {
+        if (onPaste) {
+          e.preventDefault();
+          setContextMenuPos({ x: e.clientX, y: e.clientY });
+        }
+      }}
+      style={{ height: '100%' }}
+    >
+      <SortableListPanel
       title="キャラクター"
       headerActions={
         <div style={{ display: 'flex', alignItems: 'center', gap: '1px' }}>
@@ -205,7 +217,24 @@ export function CharacterPanel({
           </Tooltip>
         </SortableListItem>
       ))}
-    </SortableListPanel>
+      </SortableListPanel>
+    </div>
+
+    <DropdownMenu
+      mode="context"
+      open={contextMenuPos !== null}
+      onOpenChange={(open) => { if (!open) setContextMenuPos(null); }}
+      position={contextMenuPos ?? { x: 0, y: 0 }}
+      items={[
+        {
+          label: '貼り付け',
+          onClick: () => {
+            onPaste?.();
+            setContextMenuPos(null);
+          },
+        },
+      ]}
+    />
 
     {pendingRemove && (
       <ConfirmModal

--- a/src/components/Adrastea/DebugConsole.tsx
+++ b/src/components/Adrastea/DebugConsole.tsx
@@ -86,10 +86,24 @@ export function DebugConsoleContent() {
     const text = filtered.map(e =>
       `${new Date(e.timestamp).toLocaleTimeString()} [${e.level}] ${e.args}`
     ).join('\n');
-    navigator.clipboard.writeText(text).then(() => {
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    } else {
+      // non-secure context fallback
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    }
   }, [filtered]);
 
   return (

--- a/src/components/Adrastea/DockLayout.tsx
+++ b/src/components/Adrastea/DockLayout.tsx
@@ -21,7 +21,7 @@ import { BgmEngine } from './BgmEngine';
 import { ErrorBoundary } from './ui/ErrorBoundary';
 import { ZoomBar } from './ZoomBar';
 import { fixGroupWidth, relaxGroupWidth, fixAllNonBoardWidths } from './dock-panels/dockColumnState';
-import { getDefaultLayoutForRole, scaleLayout, DEFAULT_LAYOUT_OWNER, DEFAULT_LAYOUT_USER, DEFAULT_LAYOUT_GUEST } from '../../services/layoutStorage';
+import { getDefaultLayoutForRole, scaleLayout, DEFAULT_LAYOUT_OWNER, DEFAULT_LAYOUT_USER, DEFAULT_LAYOUT_GUEST, loadStore, persistStore } from '../../services/layoutStorage';
 
 /* ── レイアウト保存/復元 ── */
 
@@ -44,13 +44,28 @@ const BoardTab: React.FunctionComponent<IDockviewPanelHeaderProps> = (props) => 
 
 function saveLayout(api: DockviewApi, role: string) {
   try {
+    const layoutJson = api.toJSON();
+
+    // 旧形式にも保存（互換性維持）
     localStorage.setItem(
       layoutKey(role),
       JSON.stringify({
         _version: LAYOUT_VERSION,
-        layout: api.toJSON(),
+        layout: layoutJson,
       }),
     );
+
+    // 新形式のストアにも保存
+    const store = loadStore();
+    const defaultKey = (role === 'owner' || role === 'sub_owner') ? 'gmDefault' : 'plDefault';
+    const defaultId = store[defaultKey as keyof typeof store];
+    if (defaultId && typeof defaultId === 'string') {
+      const layoutEntry = store.layouts.find(l => l.id === defaultId);
+      if (layoutEntry) {
+        layoutEntry.layout = layoutJson;
+        persistStore(store);
+      }
+    }
   } catch { /* ignore */ }
 }
 

--- a/src/components/Adrastea/dock-panels/BoardDockPanel.tsx
+++ b/src/components/Adrastea/dock-panels/BoardDockPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useMemo } from 'react';
 import { useAdrasteaContext } from '../../../contexts/AdrasteaContext';
 import { useAuth } from '../../../contexts/AuthContext';
 import { hasRole } from '../../../config/permissions';
+import { handleClipboardImport } from '../../../hooks/usePasteHandler';
 import { Board } from '../Board';
 import { AssetLibraryModal } from '../AssetLibraryModal';
 import { MessagePopup } from '../ui/MessagePopup';
@@ -52,6 +53,15 @@ export function BoardDockPanel() {
     if (obj?.type === 'text') return;
     setImagePickerTarget({ id });
   }, [ctx.activeObjects]);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      await handleClipboardImport(text, ctx.addCharacter, ctx.showToast);
+    } catch {
+      ctx.showToast('クリップボードの読み取りに失敗しました', 'error');
+    }
+  }, [ctx.addCharacter, ctx.showToast]);
 
   const latestMessage = useMemo(() => {
     if (!ctx.messages || ctx.messages.length === 0) return null;
@@ -108,6 +118,7 @@ export function BoardDockPanel() {
           selectedObjectId={ctx.editingObjectId}
           selectedObjectIds={ctx.selectedObjectIds}
           selectedCharacterId={ctx.editingCharacter?.id ?? null}
+          onPaste={handlePaste}
         >
           <MessagePopup message={latestMessage} charColor={latestCharColor} />
         </Board>

--- a/src/components/Adrastea/dock-panels/CharacterDockPanel.tsx
+++ b/src/components/Adrastea/dock-panels/CharacterDockPanel.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAdrasteaContext } from '../../../contexts/AdrasteaContext';
 import { useAuth } from '../../../contexts/AuthContext';
+import { handleClipboardImport } from '../../../hooks/usePasteHandler';
 import { CharacterPanel } from '../CharacterPanel';
 import { CharacterEditor, type CharacterEditorHandle } from '../CharacterEditor';
 import { AdModal } from '../ui';
@@ -75,6 +76,15 @@ export function CharacterDockPanel() {
     ctx.updateCharacter(charId, { board_visible: char.board_visible !== false ? false : true });
   };
 
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      await handleClipboardImport(text, ctx.addCharacter, ctx.showToast);
+    } catch {
+      ctx.showToast('クリップボードの読み取りに失敗しました', 'error');
+    }
+  }, [ctx.addCharacter, ctx.showToast]);
+
   return (
     <>
       <CharacterPanel
@@ -89,6 +99,7 @@ export function CharacterDockPanel() {
         onRemoveCharacters={handleRemoveCharacters}
         onReorderCharacters={ctx.reorderCharacters}
         onToggleBoardVisible={handleToggleBoardVisible}
+        onPaste={handlePaste}
       />
       {modalChar !== undefined && ctx.roomId && (
         <AdModal

--- a/src/components/Adrastea/dock-panels/LayerDockPanel.tsx
+++ b/src/components/Adrastea/dock-panels/LayerDockPanel.tsx
@@ -1,5 +1,48 @@
+import { useState, useCallback } from 'react';
+import { useAdrasteaContext } from '../../../contexts/AdrasteaContext';
+import { handleClipboardImport } from '../../../hooks/usePasteHandler';
+import { DropdownMenu } from '../ui';
 import { LayerPanel } from '../LayerPanel';
 
 export function LayerDockPanel() {
-  return <LayerPanel />;
+  const ctx = useAdrasteaContext();
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      await handleClipboardImport(text, ctx.addCharacter, ctx.showToast);
+    } catch {
+      ctx.showToast('クリップボードの読み取りに失敗しました', 'error');
+    }
+  }, [ctx.addCharacter, ctx.showToast]);
+
+  return (
+    <>
+      <div
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setContextMenuPos({ x: e.clientX, y: e.clientY });
+        }}
+        style={{ height: '100%' }}
+      >
+        <LayerPanel />
+      </div>
+      <DropdownMenu
+        mode="context"
+        open={contextMenuPos !== null}
+        onOpenChange={(open) => { if (!open) setContextMenuPos(null); }}
+        position={contextMenuPos ?? { x: 0, y: 0 }}
+        items={[
+          {
+            label: '貼り付け',
+            onClick: () => {
+              handlePaste();
+              setContextMenuPos(null);
+            },
+          },
+        ]}
+      />
+    </>
+  );
 }

--- a/src/components/Adrastea/dock-panels/StatusDockPanel.tsx
+++ b/src/components/Adrastea/dock-panels/StatusDockPanel.tsx
@@ -3,6 +3,8 @@ import { ExternalLink } from 'lucide-react';
 import { useAdrasteaContext } from '../../../contexts/AdrasteaContext';
 import { useAuth } from '../../../contexts/AuthContext';
 import { hasRole } from '../../../config/permissions';
+import { handleClipboardImport } from '../../../hooks/usePasteHandler';
+import { DropdownMenu } from '../ui';
 import { theme } from '../../../styles/theme';
 
 function isLightColor(hex: string): boolean {
@@ -189,6 +191,7 @@ export function StatusDockPanel() {
   const ctx = useAdrasteaContext();
   const { user } = useAuth();
   const currentUserId = user?.uid ?? '';
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
 
   const visible = [...ctx.characters]
     .filter(c => !c.is_hidden_on_board)
@@ -220,145 +223,177 @@ export function StatusDockPanel() {
     ctx.updateCharacter(charId, { statuses: newStatuses });
   }, [ctx]);
 
-  return (
-    <div style={{
-      height: '100%',
-      overflow: 'auto',
-      background: theme.bgSurface,
-      color: theme.textPrimary,
-      padding: 6,
-      display: 'flex',
-      flexDirection: 'column',
-      gap: 4,
-    }}>
-      {visible.length === 0 ? (
-        <div style={{ padding: 16, color: theme.textMuted, textAlign: 'center', fontSize: 12 }}>
-          表示するキャラクターがいません
-        </div>
-      ) : visible.map(char => {
-        const isOwner = char.owner_id === currentUserId;
-        const imgUrl = char.images[char.active_image_index]?.url ?? null;
-        const isPrivate = char.is_status_private && !isOwner && !isSubOwnerPlus;
-        const initiative = char.initiative ?? 0;
-        const textColor = isLightColor(char.color) ? '#000' : '#fff';
-        const showStatuses = !isPrivate && char.statuses.length > 0;
-        const hasSheetUrl = !!char.sheet_url;
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      await handleClipboardImport(text, ctx.addCharacter, ctx.showToast);
+    } catch {
+      ctx.showToast('クリップボードの読み取りに失敗しました', 'error');
+    }
+  }, [ctx.addCharacter, ctx.showToast]);
 
-        return (
-          <div
-            key={char.id}
-            style={{
-              display: 'flex',
-              gap: 6,
-              padding: 4,
-              borderLeft: `3px solid ${char.color}`,
-              borderBottom: `1px solid ${theme.borderSubtle}`,
-            }}
-          >
-            {/* アイコン + イニシアチブバッジ */}
-            <div
-              style={{ position: 'relative', flexShrink: 0, cursor: (isOwner || isSubOwnerPlus) ? 'pointer' : 'default' }}
-              onClick={() => handleClick(char.id)}
-              onDoubleClick={() => handleDoubleClick(char.id)}
-            >
-              {imgUrl ? (
-                <img
-                  src={imgUrl}
-                  style={{ width: 48, height: 48, objectFit: 'cover', objectPosition: 'top', display: 'block' }}
-                  draggable={false}
-                />
-              ) : (
-                <div style={{
-                  width: 48, height: 48, background: char.color,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  color: '#fff', fontSize: 18, fontWeight: 700,
-                }}>
-                  {char.name.charAt(0)}
-                </div>
-              )}
-              {/* イニシアチブバッジ */}
-              <div style={{
-                position: 'absolute',
-                top: -2,
-                left: -2,
-                background: char.color,
-                color: textColor,
-                fontSize: 12,
-                fontWeight: 700,
-                padding: '0 3px',
-                lineHeight: '16px',
-                minWidth: 16,
-                textAlign: 'center',
-              }}>
-                {isPrivate ? '?' : formatInitiative(initiative)}
-              </div>
-            </div>
-            {/* 右側: 名前 + ステータスバー */}
-            <div style={{ flex: 1, minWidth: 0 }}>
-              {/* 名前行: 名前 + 右端にボタン群 */}
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                marginBottom: 2,
-              }}>
-                {/* 名前 */}
-                <span style={{
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: theme.textPrimary,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  flex: 1,
-                }}>
-                  {char.name}
-                </span>
-                {/* 外部URL */}
-                <button
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: hasSheetUrl ? 'pointer' : 'default',
-                    opacity: hasSheetUrl ? 0.8 : 0.25,
-                    color: theme.textPrimary,
-                    display: 'flex',
-                    alignItems: 'center',
-                  }}
-                  title={hasSheetUrl ? char.sheet_url! : '外部URLが未設定'}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (hasSheetUrl) window.open(char.sheet_url!, '_blank', 'noopener');
-                  }}
-                  disabled={!hasSheetUrl}
-                >
-                  <ExternalLink size={11} />
-                </button>
-              </div>
-              {/* ステータスバー 2列グリッド */}
-              {showStatuses && (
-                <div style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(2, 1fr)',
-                  gap: 2,
-                }}>
-                  {char.statuses.map((s, i) => (
-                    <StatusBar
-                      key={i}
-                      charId={char.id}
-                      statusIndex={i}
-                      status={s}
-                      canEdit={isOwner || isSubOwnerPlus}
-                      updateStatusValue={updateStatusValue}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
+  return (
+    <>
+      <div
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setContextMenuPos({ x: e.clientX, y: e.clientY });
+        }}
+        style={{
+          height: '100%',
+          overflow: 'auto',
+          background: theme.bgSurface,
+          color: theme.textPrimary,
+          padding: 6,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+        }}
+      >
+        {visible.length === 0 ? (
+          <div style={{ padding: 16, color: theme.textMuted, textAlign: 'center', fontSize: 12 }}>
+            表示するキャラクターがいません
           </div>
-        );
-      })}
-    </div>
+        ) : visible.map(char => {
+          const isOwner = char.owner_id === currentUserId;
+          const imgUrl = char.images[char.active_image_index]?.url ?? null;
+          const isPrivate = char.is_status_private && !isOwner && !isSubOwnerPlus;
+          const initiative = char.initiative ?? 0;
+          const textColor = isLightColor(char.color) ? '#000' : '#fff';
+          const showStatuses = !isPrivate && char.statuses.length > 0;
+          const hasSheetUrl = !!char.sheet_url;
+
+          return (
+            <div
+              key={char.id}
+              style={{
+                display: 'flex',
+                gap: 6,
+                padding: 4,
+                borderLeft: `3px solid ${char.color}`,
+                borderBottom: `1px solid ${theme.borderSubtle}`,
+              }}
+            >
+              {/* アイコン + イニシアチブバッジ */}
+              <div
+                style={{ position: 'relative', flexShrink: 0, cursor: (isOwner || isSubOwnerPlus) ? 'pointer' : 'default' }}
+                onClick={() => handleClick(char.id)}
+                onDoubleClick={() => handleDoubleClick(char.id)}
+              >
+                {imgUrl ? (
+                  <img
+                    src={imgUrl}
+                    style={{ width: 48, height: 48, objectFit: 'cover', objectPosition: 'top', display: 'block' }}
+                    draggable={false}
+                  />
+                ) : (
+                  <div style={{
+                    width: 48, height: 48, background: char.color,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#fff', fontSize: 18, fontWeight: 700,
+                  }}>
+                    {char.name.charAt(0)}
+                  </div>
+                )}
+                {/* イニシアチブバッジ */}
+                <div style={{
+                  position: 'absolute',
+                  top: -2,
+                  left: -2,
+                  background: char.color,
+                  color: textColor,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  padding: '0 3px',
+                  lineHeight: '16px',
+                  minWidth: 16,
+                  textAlign: 'center',
+                }}>
+                  {isPrivate ? '?' : formatInitiative(initiative)}
+                </div>
+              </div>
+              {/* 右側: 名前 + ステータスバー */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                {/* 名前行: 名前 + 右端にボタン群 */}
+                <div style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  marginBottom: 2,
+                }}>
+                  {/* 名前 */}
+                  <span style={{
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: theme.textPrimary,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    flex: 1,
+                  }}>
+                    {char.name}
+                  </span>
+                  {/* 外部URL */}
+                  <button
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      cursor: hasSheetUrl ? 'pointer' : 'default',
+                      opacity: hasSheetUrl ? 0.8 : 0.25,
+                      color: theme.textPrimary,
+                      display: 'flex',
+                      alignItems: 'center',
+                    }}
+                    title={hasSheetUrl ? char.sheet_url! : '外部URLが未設定'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (hasSheetUrl) window.open(char.sheet_url!, '_blank', 'noopener');
+                    }}
+                    disabled={!hasSheetUrl}
+                  >
+                    <ExternalLink size={11} />
+                  </button>
+                </div>
+                {/* ステータスバー 2列グリッド */}
+                {showStatuses && (
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(2, 1fr)',
+                    gap: 2,
+                  }}>
+                    {char.statuses.map((s, i) => (
+                      <StatusBar
+                        key={i}
+                        charId={char.id}
+                        statusIndex={i}
+                        status={s}
+                        canEdit={isOwner || isSubOwnerPlus}
+                        updateStatusValue={updateStatusValue}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <DropdownMenu
+        mode="context"
+        open={contextMenuPos !== null}
+        onOpenChange={(open) => { if (!open) setContextMenuPos(null); }}
+        position={contextMenuPos ?? { x: 0, y: 0 }}
+        items={[
+          {
+            label: '貼り付け',
+            onClick: () => {
+              handlePaste();
+              setContextMenuPos(null);
+            },
+          },
+        ]}
+      />
+    </>
   );
 }

--- a/src/components/Adrastea/ui/DropdownMenu.tsx
+++ b/src/components/Adrastea/ui/DropdownMenu.tsx
@@ -134,6 +134,16 @@ export function DropdownMenu({
     setMenuInitialized(true);
   }, [isOpen, align, direction, mode]);
 
+  // --- Sync position to menuPos in context mode ---
+  useEffect(() => {
+    if (mode === 'context' && isOpen && position) {
+      setMenuPos({ top: position.y, left: position.x });
+    } else if (mode === 'context' && !isOpen) {
+      setMenuPos(null);
+      setHoveredIndex(null);
+    }
+  }, [mode, isOpen, position?.x, position?.y]);
+
   // --- Handle click-outside (mode-dependent) ---
   useEffect(() => {
     if (!isOpen) return;

--- a/src/components/Adrastea/ui/Toast.tsx
+++ b/src/components/Adrastea/ui/Toast.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { theme } from '../../../styles/theme';
+
+export type Toast = {
+  id: string;
+  message: string;
+  type: 'success' | 'error';
+};
+
+export function useToast(): {
+  toasts: Toast[];
+  showToast: (message: string, type: 'success' | 'error') => void;
+} {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, type: 'success' | 'error') => {
+    const id = Date.now().toString();
+    const newToast: Toast = { id, message, type };
+
+    setToasts((prev) => [...prev, newToast]);
+
+    // 3秒後に自動削除
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return { toasts, showToast };
+}
+
+export function ToastContainer({ toasts }: { toasts: Toast[] }) {
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        top: '16px',
+        right: '16px',
+        zIndex: 10002,
+        pointerEvents: 'none',
+      }}
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            backgroundColor: toast.type === 'success' ? theme.success : theme.danger,
+            color: '#fff',
+            padding: '12px 20px',
+            borderRadius: '6px',
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            boxShadow: theme.shadowMd,
+            marginBottom: '8px',
+            pointerEvents: 'auto',
+          }}
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>,
+    document.body
+  );
+}

--- a/src/contexts/AdrasteaContext.tsx
+++ b/src/contexts/AdrasteaContext.tsx
@@ -32,6 +32,7 @@ import { useAuth } from './AuthContext';
 import { RoomDataContext, UIStateContext } from './AdrasteaContexts';
 import type { RoomDataContextValue, UIStateContextValue } from './AdrasteaContexts';
 import { checkPermission, type PermissionKey } from '../config/permissions';
+import { useToast } from '../components/Adrastea/ui/Toast';
 
 // ---------------------------------------------------------------------------
 // Pending edits types
@@ -210,6 +211,10 @@ export interface AdrasteaContextValue {
   // --- パネル登録（遅延リスナー用） ---
   registerPanel: (panelId: string) => void;
   unregisterPanel: (panelId: string) => void;
+
+  // --- Toast ---
+  toasts: { id: string; message: string; type: 'success' | 'error' }[];
+  showToast: (message: string, type: 'success' | 'error') => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -231,6 +236,8 @@ interface AdrasteaProviderProps {
 export const AdrasteaProvider: React.FC<AdrasteaProviderProps> = ({ children, roomId, roomRole }) => {
   const { user, profile, signOut, updateProfile: updateProfileFromAuth } = useAuth();
   const updateProfile = updateProfileFromAuth ?? (async () => {});
+
+  const { toasts, showToast } = useToast();
 
   // --- Convex mutations ---
   const removeRoom = useMutation(api.rooms.remove);
@@ -879,6 +886,9 @@ export const AdrasteaProvider: React.FC<AdrasteaProviderProps> = ({ children, ro
 
       // パネル登録
       registerPanel, unregisterPanel,
+
+      // Toast
+      toasts, showToast,
     }),
     [
       roomId, roomRole,
@@ -910,6 +920,7 @@ export const AdrasteaProvider: React.FC<AdrasteaProviderProps> = ({ children, ro
       setPendingEdit,
       clearAllEditing,
       registerPanel, unregisterPanel,
+      toasts, showToast,
     ],
   );
 

--- a/src/hooks/usePasteHandler.ts
+++ b/src/hooks/usePasteHandler.ts
@@ -1,0 +1,86 @@
+import { useEffect, useCallback } from 'react';
+import { parseClipboardData } from '../utils/clipboardImport';
+import type { Character } from '../types/adrastea.types';
+
+export interface UsePasteHandlerOptions {
+  addCharacter: (data: Partial<Character>) => Promise<any>;
+  showToast: (message: string, type: 'success' | 'error') => void;
+}
+
+/**
+ * クリップボードのテキスト内容をハンドルする共通ロジック
+ * paste イベントハンドラ、またはコンテキストメニューからの呼び出し用
+ */
+export async function handleClipboardImport(
+  text: string,
+  addCharacter: (data: Partial<Character>) => Promise<any>,
+  showToast: (message: string, type: 'success' | 'error') => void,
+): Promise<void> {
+  const result = parseClipboardData(text);
+
+  if (result === null) {
+    // 対応フォーマットではない（JSON ではない、kind プロパティなし）
+    // 何もしない
+    return;
+  }
+
+  if (result.type === 'unknown') {
+    showToast('対応していない形式です', 'error');
+    return;
+  }
+
+  if (result.type === 'character') {
+    try {
+      await addCharacter(result.data);
+      const charName = result.data.name ?? '不明';
+      showToast(`キャラクター "${charName}" をインポートしました`, 'success');
+    } catch {
+      showToast('インポートに失敗しました', 'error');
+    }
+  }
+}
+
+/**
+ * グローバル paste イベントを監視し、
+ * クリップボード内容に応じてキャラクターインポートやトースト表示を行うフック
+ */
+export function usePasteHandler({ addCharacter, showToast }: UsePasteHandlerOptions): void {
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
+      // テキスト入力中はスキップ（通常のペースト動作を妨げない）
+      const activeElement = document.activeElement as HTMLElement | null;
+      if (activeElement) {
+        const tagName = activeElement.tagName;
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+          return;
+        }
+        if (activeElement.contentEditable === 'true') {
+          return;
+        }
+      }
+
+      const text = e.clipboardData?.getData('text/plain');
+      if (!text) {
+        return;
+      }
+
+      // フォーマット判定を同期的に行い、対象なら preventDefault
+      const result = parseClipboardData(text);
+      if (result === null) {
+        return;
+      }
+      e.preventDefault();
+
+      // 非同期でインポート処理
+      handleClipboardImport(text, addCharacter, showToast);
+    },
+    [addCharacter, showToast],
+  );
+
+  useEffect(() => {
+    document.addEventListener('paste', handlePaste as EventListener);
+    return () => {
+      document.removeEventListener('paste', handlePaste as EventListener);
+    };
+  }, [handlePaste]);
+}

--- a/src/hooks/useRooms.ts
+++ b/src/hooks/useRooms.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '../../convex/_generated/api';
+import { generateUUID } from '../utils/uuid';
 
 const ROOM_ORDER_KEY = 'adrastea-room-order';
 const ROOM_TAGS_PREFIX = 'adrastea-room-tags-';
@@ -124,7 +125,7 @@ export function useRooms(_uid?: string) {
 
   const addRoom = useCallback(
     async (name: string, dice_system: string, _tags: string[]): Promise<string> => {
-      const id = crypto.randomUUID();
+      const id = generateUUID();
       await createMutation({ id, name, dice_system, gm_can_see_secret_memo: false });
       return id;
     },

--- a/src/pages/Adrastea.tsx
+++ b/src/pages/Adrastea.tsx
@@ -11,6 +11,8 @@ import { OnboardingModal } from '../components/Adrastea/OnboardingModal';
 import { AdrasteaProvider, useAdrasteaContext } from '../contexts/AdrasteaContext';
 import { useAuth } from '../contexts/AuthContext';
 import { usePermission } from '../hooks/usePermission';
+import { ToastContainer } from '../components/Adrastea/ui/Toast';
+import { usePasteHandler } from '../hooks/usePasteHandler';
 import { theme } from '../styles/theme';
 
 /** 共通ローディング画面 */
@@ -51,6 +53,9 @@ function AdrasteaRoom() {
   const { can } = usePermission();
   const { isGuest } = useAuth();
   const isOwner = ctx.roomRole === 'owner';
+
+  // クリップボードインポート
+  usePasteHandler({ addCharacter: ctx.addCharacter, showToast: ctx.showToast });
 
   // メンバー管理（ownerのみ実データ取得）
   const members = useQuery(
@@ -166,6 +171,9 @@ function AdrasteaRoom() {
           onClose={() => ctx.setShowSettings(false)}
         />
       )}
+
+      {/* トースト通知 */}
+      <ToastContainer toasts={ctx.toasts} />
     </div>
   );
 }

--- a/src/services/layoutStorage.ts
+++ b/src/services/layoutStorage.ts
@@ -1,3 +1,5 @@
+import { generateUUID } from '../utils/uuid';
+
 // localStorage キー
 const STORE_KEY = 'adrastea-layouts';
 const LEGACY_OWNER_KEY = 'adrastea-dock-layout-owner';
@@ -19,8 +21,8 @@ export interface LayoutStore {
 
 // 初期値を生成する関数
 function createInitialStore(): LayoutStore {
-  const gmId = crypto.randomUUID();
-  const plId = crypto.randomUUID();
+  const gmId = generateUUID();
+  const plId = generateUUID();
   return {
     version: 1,
     layouts: [
@@ -74,7 +76,7 @@ function migrateFromLegacy(): LayoutStore {
       const parsed = JSON.parse(legacyOwner) as { _version?: number; layout?: object };
       if (parsed._version === 3 && parsed.layout) {
         const ownerLayout: SavedLayout = {
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           name: '(自動保存)',
           layout: parsed.layout,
         };
@@ -92,7 +94,7 @@ function migrateFromLegacy(): LayoutStore {
       const parsed = JSON.parse(legacyUser) as { _version?: number; layout?: object };
       if (parsed._version === 3 && parsed.layout) {
         const userLayout: SavedLayout = {
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           name: '(自動保存)',
           layout: parsed.layout,
         };
@@ -127,11 +129,11 @@ export function getSavedLayouts(): SavedLayout[] {
 }
 
 /**
- * レイアウト保存（新規追加）。id は crypto.randomUUID() で生成。返り値は id
+ * レイアウト保存（新規追加）。id は generateUUID() で生成。返り値は id
  */
 export function addLayout(name: string, layout: object): string {
   const currentStore = loadStore();
-  const id = crypto.randomUUID();
+  const id = generateUUID();
   const newLayout: SavedLayout = {
     id,
     name,

--- a/src/utils/clipboardImport.ts
+++ b/src/utils/clipboardImport.ts
@@ -1,0 +1,123 @@
+import type { Character } from '../types/adrastea.types';
+
+export type ClipboardParseResult =
+  | { type: 'character'; data: Partial<Character> }
+  | { type: 'unknown'; kind: string }
+  | null;
+
+/**
+ * クリップボードテキストを解析し、Adrastea のデータ型に変換する
+ */
+export function parseClipboardData(text: string): ClipboardParseResult {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // JSON ですらない
+    return null;
+  }
+
+  // parsed が object ではない、または null の場合
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  // kind プロパティがない場合
+  if (!('kind' in obj)) {
+    return null;
+  }
+
+  const kind = obj.kind;
+
+  // kind が character の場合
+  if (kind === 'character') {
+    const data = parseIacharaCharacter(obj.data);
+    return { type: 'character', data };
+  }
+
+  // kind が存在するが 'character' 以外の場合
+  if (typeof kind === 'string') {
+    return { type: 'unknown', kind };
+  }
+
+  return null;
+}
+
+/**
+ * iachara 形式のキャラクターデータを Adrastea Character に変換する
+ */
+function parseIacharaCharacter(raw: unknown): Partial<Character> {
+  if (typeof raw !== 'object' || raw === null) {
+    return {};
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const result: Partial<Character> = {};
+
+  // name
+  if (typeof obj.name === 'string') {
+    result.name = obj.name;
+  }
+
+  // images (iconUrl から)
+  if (typeof obj.iconUrl === 'string' && obj.iconUrl) {
+    result.images = [{ url: obj.iconUrl, label: 'メイン' }];
+    result.active_image_index = 0;
+  }
+
+  // sheet_url (externalUrl から)
+  if (typeof obj.externalUrl === 'string' || obj.externalUrl === null) {
+    result.sheet_url = obj.externalUrl;
+  }
+
+  // initiative
+  if (obj.initiative !== undefined) {
+    result.initiative = Number(obj.initiative) || 0;
+  }
+
+  // color
+  if (typeof obj.color === 'string') {
+    result.color = obj.color;
+  } else {
+    result.color = '#555555';
+  }
+
+  // statuses
+  if (Array.isArray(obj.status)) {
+    result.statuses = obj.status.map((s: unknown) => {
+      if (typeof s !== 'object' || s === null) {
+        return { label: '', value: 0, max: 0 };
+      }
+      const statusObj = s as Record<string, unknown>;
+      return {
+        label: typeof statusObj.label === 'string' ? statusObj.label : '',
+        value: Number(statusObj.value) || 0,
+        max: Number(statusObj.max) || 0,
+      };
+    });
+  }
+
+  // parameters
+  if (Array.isArray(obj.params)) {
+    result.parameters = obj.params.map((p: unknown) => {
+      if (typeof p !== 'object' || p === null) {
+        return { label: '', value: '' };
+      }
+      const paramObj = p as Record<string, unknown>;
+      return {
+        label: typeof paramObj.label === 'string' ? paramObj.label : '',
+        value: typeof paramObj.value === 'string' ? paramObj.value : '',
+      };
+    });
+  }
+
+  // chat_palette (commands から)
+  if (typeof obj.commands === 'string') {
+    result.chat_palette = obj.commands;
+  }
+
+  return result;
+}

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,18 @@
+/**
+ * crypto.randomUUID() の安全なラッパー。
+ * non-secure context（HTTP over LAN など）では crypto.randomUUID が未定義になるため、
+ * フォールバックとして crypto.getRandomValues ベースの UUID v4 を生成する。
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  // fallback: crypto.getRandomValues ベースの UUID v4
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), basicSsl()],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- iachara 形式 JSON のクリップボードインポート機能（Ctrl+V + 右クリック「貼り付け」）
- Toast 通知システム、クリップボードパーサー、グローバル paste ハンドラを新規実装
- 対象パネル: キャラクター / ボード / レイヤー / ステータス
- DropdownMenu context mode バグ修正、non-secure context 対応、レイアウト自動保存修正

## Test plan
- [ ] iachara JSON を Ctrl+V → キャラクター作成 + 成功トースト
- [ ] 各パネル右クリック →「貼り付け」→ キャラクター作成
- [ ] `{"kind":"unknown"}` をペースト →「対応していない形式です」トースト
- [ ] 普通テキスト Ctrl+V → 何も起きない
- [ ] チャット入力欄フォーカス中 Ctrl+V → 通常ペースト（干渉なし）
- [ ] LAN IP (HTTPS) で crypto.randomUUID エラーなし
- [ ] レイアウト変更 → リロード → 保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)